### PR TITLE
storage: introduce storage module

### DIFF
--- a/firmware/3-key.cpp
+++ b/firmware/3-key.cpp
@@ -5,6 +5,7 @@
 #include "config.hpp"
 #include "hid.hpp"
 #include "leds.hpp"
+#include "storage.hpp"
 #include "terminal.hpp"
 #include "tud.hpp"
 
@@ -25,6 +26,29 @@ int main(void) {
         { 2, BUTTON_LEFT_GPIO, Modifier::LEFT_CMD, Color::Blue },
     };
 
+    Storage storage;
+
+    /*
+    This is only example usage of Storage module.
+    The statuses have been discarded here on purpose.
+    */
+    constexpr uint config_slot = 31;
+
+    config_t config;
+    storage.get_config(config_slot, config);
+
+    if (config.magic != CONFIG_MAGIC) {
+        config.magic         = CONFIG_MAGIC;
+        config.config_value1 = 42;
+        config.config_value2 = 1337;
+        storage.save_config(config_slot, config);
+    }
+
+    config.config_value1 += 1;
+    config.config_value2 -= 1;
+    storage.save_config(config_slot, config);
+    /* End of example */
+
     Leds leds(key_configs.size());
     leds.init();
 
@@ -35,7 +59,7 @@ int main(void) {
     g_leds    = &leds;
     multicore_launch_core1(leds_task_on_core1);
 
-    Terminal t;
+    Terminal t(storage);
     CdcDevice cdc(t);
 
     initialize_tud();

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -31,6 +31,7 @@ target_include_directories(${project_name} PUBLIC
 add_subdirectory(buttons)
 add_subdirectory(leds)
 add_subdirectory(usb)
+add_subdirectory(storage)
 add_subdirectory(terminal)
 
 target_link_libraries(${project_name} 
@@ -39,6 +40,7 @@ target_link_libraries(${project_name}
     buttons
     leds
     usb
+    storage 
     terminal
 )
 

--- a/firmware/storage/CMakeLists.txt
+++ b/firmware/storage/CMakeLists.txt
@@ -1,10 +1,10 @@
-set(modulename "terminal")
+set(modulename "storage")
 set(SOURCES 
-        terminal.cpp
+        storage.cpp
 )
 add_library(${modulename} ${SOURCES})
 target_include_directories(${modulename} PUBLIC include)
 target_link_libraries(${modulename}
-        pico_stdlib
-        storage
+    pico_stdlib
+    hardware_flash
 )

--- a/firmware/storage/include/storage.hpp
+++ b/firmware/storage/include/storage.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <vector>
+
+#include "hardware/flash.h"
+#include "hardware/sync.h"
+
+#include "storage_config.hpp"
+
+typedef struct {
+    uint32_t magic;
+    uint32_t config_value1;
+    uint32_t config_value2;
+    uint8_t reserved[500];
+} config_t;
+
+static_assert(sizeof(config_t) == CONFIG_SLOT_SIZE_BYTES, "Structure must have the configured size.");
+
+enum StorageStatus {
+    SUCCESS,
+    INVALID_ID,
+    INVALID_INPUT,
+    ERROR,
+};
+
+class Storage {
+  public:
+    Storage();
+    ~Storage() = default;
+
+  private:
+    static constexpr uint configs_per_section = FLASH_SECTOR_SIZE / CONFIG_SLOT_SIZE_BYTES;
+    std::vector<config_t> sector;
+    uint32_t max_config_id;
+    const uint8_t* storage_start_addr;
+
+    const uint8_t* get_config_address(uint config_id) const;
+    uint get_sector_id(uint config_id) const;
+    StorageStatus update_config_in_sector(uint config_id, config_t& config);
+    StorageStatus read_sector(uint sector_id);
+    void save_sector(uint sector_id) const;
+
+  public:
+    void erase() const;
+    void erase(uint sector_id) const;
+
+    StorageStatus get_config(uint config_id, config_t& output) const;
+    StorageStatus save_config(uint config_id, config_t& config);
+};

--- a/firmware/storage/include/storage_config.hpp
+++ b/firmware/storage/include/storage_config.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "hardware/flash.h"
+
+#define CONFIG_SLOTS_COUNT 32
+#define CONFIG_SLOT_SIZE_BYTES 512
+#define CONFIG_MAGIC 0xDEADBEEF
+
+#define STORAGE_SIZE (CONFIG_SLOTS_COUNT * CONFIG_SLOT_SIZE_BYTES)
+static_assert((STORAGE_SIZE % FLASH_SECTOR_SIZE) == 0, "The size of the storage must be multiple of sector size.");
+
+#define STORAGE_FLASH_OFFSET (PICO_FLASH_SIZE_BYTES - STORAGE_SIZE)

--- a/firmware/storage/storage.cpp
+++ b/firmware/storage/storage.cpp
@@ -1,0 +1,108 @@
+#include <cstring>
+#include <limits>
+
+#include "storage.hpp"
+
+Storage::Storage() {
+    sector.resize(FLASH_SECTOR_SIZE / sizeof(config_t));
+    max_config_id      = (STORAGE_SIZE / sizeof(config_t)) - 1;
+    storage_start_addr = (const uint8_t*)(XIP_BASE + STORAGE_FLASH_OFFSET);
+}
+
+void Storage::erase() const {
+    uint32_t interrupts = save_and_disable_interrupts();
+    flash_range_erase(STORAGE_FLASH_OFFSET & ~(FLASH_SECTOR_SIZE - 1), STORAGE_SIZE);
+    restore_interrupts(interrupts);
+}
+
+void Storage::erase(uint sector_id) const {
+    uint32_t interrupts         = save_and_disable_interrupts();
+    const uintptr_t sector_addr = STORAGE_FLASH_OFFSET + (sector_id * FLASH_SECTOR_SIZE);
+    flash_range_erase(sector_addr & ~(FLASH_SECTOR_SIZE - 1), FLASH_SECTOR_SIZE);
+    restore_interrupts(interrupts);
+}
+
+const uint8_t* Storage::get_config_address(uint config_id) const {
+    if (config_id > max_config_id) {
+        return nullptr;
+    }
+
+    return (storage_start_addr + (config_id * sizeof(config_t)));
+}
+
+StorageStatus Storage::get_config(uint config_id, config_t& output) const {
+    if (config_id > max_config_id) {
+        return StorageStatus::INVALID_ID;
+    }
+
+    memcpy(&output, get_config_address(config_id), sizeof(config_t));
+
+    return StorageStatus::SUCCESS;
+}
+
+uint Storage::get_sector_id(uint config_id) const {
+    if (config_id > max_config_id) {
+        return std::numeric_limits<unsigned int>::max();
+    }
+
+    return config_id / configs_per_section;
+}
+
+StorageStatus Storage::read_sector(uint sector_id) {
+    const uint start_config_id = sector_id * configs_per_section;
+
+    for (int i = 0; i < configs_per_section; i++) {
+        StorageStatus status = get_config(start_config_id + i, sector[i]);
+        if (status != StorageStatus::SUCCESS) {
+            return status;
+        }
+    }
+
+    return StorageStatus::SUCCESS;
+}
+
+StorageStatus Storage::update_config_in_sector(uint config_id, config_t& config) {
+    if (config_id > max_config_id) {
+        return StorageStatus::INVALID_ID;
+    }
+
+    sector[config_id % configs_per_section] = config;
+
+    return StorageStatus::SUCCESS;
+}
+
+void Storage::save_sector(uint sector_id) const {
+    if (sector.size() * sizeof(config_t) != FLASH_SECTOR_SIZE) {
+        return;
+    }
+    const uintptr_t sector_addr = STORAGE_FLASH_OFFSET + (sector_id * FLASH_SECTOR_SIZE);
+
+    const uint32_t interrupts = save_and_disable_interrupts();
+    flash_range_program(sector_addr, reinterpret_cast<const uint8_t*>(sector.data()), FLASH_SECTOR_SIZE);
+    restore_interrupts(interrupts);
+}
+
+StorageStatus Storage::save_config(uint config_id, config_t& config) {
+    StorageStatus status = StorageStatus::ERROR;
+
+    if (config_id > max_config_id) {
+        return StorageStatus::INVALID_ID;
+    }
+
+    uint sector_id = get_sector_id(config_id);
+
+    status = read_sector(sector_id);
+    if (StorageStatus::SUCCESS != status) {
+        return status;
+    }
+
+    status = update_config_in_sector(config_id, config);
+    if (StorageStatus::SUCCESS != status) {
+        return status;
+    }
+
+    erase(sector_id);
+    save_sector(sector_id);
+
+    return StorageStatus::SUCCESS;
+}

--- a/firmware/terminal/include/terminal.hpp
+++ b/firmware/terminal/include/terminal.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "pico/stdlib.h"
+#include "storage.hpp"
 
 enum class Command {
     RESET,
@@ -19,9 +20,10 @@ class Terminal {
     static constexpr size_t max_chars         = 128;
     std::string buffer;
     size_t buff_size_bytes;
+    Storage& storage;
 
   public:
-    Terminal();
+    Terminal(Storage& storage);
     ~Terminal() = default;
     uint8_t* terminal(char new_char);
     size_t get_buff_size() const;

--- a/firmware/terminal/terminal.cpp
+++ b/firmware/terminal/terminal.cpp
@@ -1,10 +1,9 @@
 #include "terminal.hpp"
 #include "pico/bootrom.h"
-#include <cstddef>
 
 #define PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK 0u
 
-Terminal::Terminal() {
+Terminal::Terminal(Storage& storage) : storage(storage) {
     buffer += start_string;
     buff_size_bytes = start_string.length();
 }
@@ -74,7 +73,7 @@ bool Terminal::dispatch_command(Command command) const {
             return true;
         }
         case Command::ERASE: {
-            /* @TODO */
+            storage.erase();
             return true;
         }
         default: return false;


### PR DESCRIPTION
It allows to store persistent data in RPi Pico flash memory. It store is at the end of flash memory.

Example usage has been added in main().