### PR TITLE
storage: refactor storage module

### DIFF
--- a/firmware/3-key.cpp
+++ b/firmware/3-key.cpp
@@ -28,26 +28,7 @@ int main(void) {
 
     Storage storage;
 
-    /*
-    This is only example usage of Storage module.
-    The statuses have been discarded here on purpose.
-    */
-    constexpr uint config_slot = 31;
-
-    config_t config;
-    storage.get_config(config_slot, config);
-
-    if (config.magic != CONFIG_MAGIC) {
-        config.magic         = CONFIG_MAGIC;
-        config.config_value1 = 42;
-        config.config_value2 = 1337;
-        storage.save_config(config_slot, config);
-    }
-
-    config.config_value1 += 1;
-    config.config_value2 -= 1;
-    storage.save_config(config_slot, config);
-    /* End of example */
+    storage.init();
 
     Leds leds(key_configs.size());
     leds.init();

--- a/firmware/storage/include/storage.hpp
+++ b/firmware/storage/include/storage.hpp
@@ -1,20 +1,13 @@
 #pragma once
 
+#include <array>
+#include <span>
 #include <vector>
 
 #include "hardware/flash.h"
 #include "hardware/sync.h"
 
 #include "storage_config.hpp"
-
-typedef struct {
-    uint32_t magic;
-    uint32_t config_value1;
-    uint32_t config_value2;
-    uint8_t reserved[500];
-} config_t;
-
-static_assert(sizeof(config_t) == CONFIG_SLOT_SIZE_BYTES, "Structure must have the configured size.");
 
 enum StorageStatus {
     SUCCESS,
@@ -23,27 +16,49 @@ enum StorageStatus {
     ERROR,
 };
 
+using BlobBuff_t = std::array<uint8_t, BLOB_SLOT_SIZE_BYTES>;
+
 class Storage {
   public:
     Storage();
     ~Storage() = default;
+    StorageStatus init();
+    StorageStatus factory_init();
 
   private:
-    static constexpr uint configs_per_section = FLASH_SECTOR_SIZE / CONFIG_SLOT_SIZE_BYTES;
-    std::vector<config_t> sector;
-    uint32_t max_config_id;
+    StorageConfig_t s_config;
+    static constexpr uint blobs_per_sector = FLASH_SECTOR_SIZE / BLOB_SLOT_SIZE_BYTES;
+    std::vector<BlobBuff_t> sector;
+    uint32_t max_blob_id;
     const uint8_t* storage_start_addr;
 
-    const uint8_t* get_config_address(uint config_id) const;
-    uint get_sector_id(uint config_id) const;
-    StorageStatus update_config_in_sector(uint config_id, config_t& config);
+    const uint8_t* get_blob_address(uint blob_id) const;
+    uint get_sector_id(BlobType blob_type) const;
+    StorageStatus update_blob_in_sector(BlobType blob_type, std::span<uint8_t> blob);
     StorageStatus read_sector(uint sector_id);
     void save_sector(uint sector_id) const;
+    StorageStatus _get_blob(uint blob_id, std::span<uint8_t> blob) const;
+    StorageStatus _get_blob(BlobType blob_type, std::span<uint8_t> blob) const;
+    StorageStatus _save_blob(BlobType blob_type, std::span<uint8_t> blob);
+
+    bool is_factory_required();
 
   public:
     void erase() const;
     void erase(uint sector_id) const;
+    uint32_t get_init_count() const;
 
-    StorageStatus get_config(uint config_id, config_t& output) const;
-    StorageStatus save_config(uint config_id, config_t& config);
+    template <typename T> StorageStatus save_blob(BlobType blob_type, T& config) {
+        static_assert(sizeof(T) <= BLOB_SLOT_SIZE_BYTES, "Blob size exceeds the maximum blob slot size.");
+        std::span<uint8_t> blob_span(reinterpret_cast<uint8_t*>(&config), sizeof(T));
+
+        return _save_blob(blob_type, blob_span);
+    }
+
+    template <typename T> StorageStatus get_blob(BlobType blob_type, T& config) const {
+        static_assert(sizeof(T) <= BLOB_SLOT_SIZE_BYTES, "Blob size exceeds the maximum blob slot size.");
+        std::span<uint8_t> blob_span(reinterpret_cast<uint8_t*>(&config), sizeof(T));
+
+        return _get_blob(blob_type, blob_span);
+    }
 };

--- a/firmware/storage/include/storage_config.hpp
+++ b/firmware/storage/include/storage_config.hpp
@@ -2,11 +2,21 @@
 
 #include "hardware/flash.h"
 
-#define CONFIG_SLOTS_COUNT 32
-#define CONFIG_SLOT_SIZE_BYTES 512
-#define CONFIG_MAGIC 0xDEADBEEF
+#define BLOB_SLOTS_COUNT 16
+#define BLOB_SLOT_SIZE_BYTES 1024
+#define BLOB_MAGIC 0xDEADBEEF
 
-#define STORAGE_SIZE (CONFIG_SLOTS_COUNT * CONFIG_SLOT_SIZE_BYTES)
+#define STORAGE_SIZE (BLOB_SLOTS_COUNT * BLOB_SLOT_SIZE_BYTES)
 static_assert((STORAGE_SIZE % FLASH_SECTOR_SIZE) == 0, "The size of the storage must be multiple of sector size.");
 
 #define STORAGE_FLASH_OFFSET (PICO_FLASH_SIZE_BYTES - STORAGE_SIZE)
+
+typedef struct {
+    uint32_t magic;
+    uint32_t init_count;
+} StorageConfig_t;
+
+enum class BlobType : uint {
+    STORAGE_CONFIG = 1,
+    BLOBS_COUNT,
+};

--- a/firmware/storage/storage.cpp
+++ b/firmware/storage/storage.cpp
@@ -2,57 +2,106 @@
 #include <limits>
 
 #include "storage.hpp"
+#include "storage_config.hpp"
 
 Storage::Storage() {
-    sector.resize(FLASH_SECTOR_SIZE / sizeof(config_t));
-    max_config_id      = (STORAGE_SIZE / sizeof(config_t)) - 1;
+    sector.resize(blobs_per_sector);
+    max_blob_id        = (STORAGE_SIZE / BLOB_SLOT_SIZE_BYTES) - 1;
     storage_start_addr = (const uint8_t*)(XIP_BASE + STORAGE_FLASH_OFFSET);
 }
 
+StorageStatus Storage::init() {
+    StorageStatus status = StorageStatus::ERROR;
+
+    if (is_factory_required()) {
+        status = factory_init();
+        if (status != StorageStatus::SUCCESS)
+            return status;
+    }
+
+    s_config.init_count += 1;
+
+    return save_blob(BlobType::STORAGE_CONFIG, s_config);
+}
+
+StorageStatus Storage::factory_init() {
+    s_config.magic      = BLOB_MAGIC;
+    s_config.init_count = 0;
+    return save_blob(BlobType::STORAGE_CONFIG, s_config);
+}
+
+uint32_t Storage::get_init_count() const {
+    return s_config.init_count;
+}
+
+bool Storage::is_factory_required() {
+    get_blob(BlobType::STORAGE_CONFIG, s_config);
+    return (s_config.magic != BLOB_MAGIC);
+}
+
 void Storage::erase() const {
-    uint32_t interrupts = save_and_disable_interrupts();
+    const uint32_t interrupts = save_and_disable_interrupts();
     flash_range_erase(STORAGE_FLASH_OFFSET & ~(FLASH_SECTOR_SIZE - 1), STORAGE_SIZE);
     restore_interrupts(interrupts);
 }
 
 void Storage::erase(uint sector_id) const {
-    uint32_t interrupts         = save_and_disable_interrupts();
+    const uint32_t interrupts   = save_and_disable_interrupts();
     const uintptr_t sector_addr = STORAGE_FLASH_OFFSET + (sector_id * FLASH_SECTOR_SIZE);
     flash_range_erase(sector_addr & ~(FLASH_SECTOR_SIZE - 1), FLASH_SECTOR_SIZE);
     restore_interrupts(interrupts);
 }
 
-const uint8_t* Storage::get_config_address(uint config_id) const {
-    if (config_id > max_config_id) {
+const uint8_t* Storage::get_blob_address(uint blob_id) const {
+    if (blob_id > max_blob_id) {
         return nullptr;
     }
 
-    return (storage_start_addr + (config_id * sizeof(config_t)));
+    return (storage_start_addr + (blob_id * BLOB_SLOT_SIZE_BYTES));
 }
 
-StorageStatus Storage::get_config(uint config_id, config_t& output) const {
-    if (config_id > max_config_id) {
+StorageStatus Storage::_get_blob(BlobType blob_type, std::span<uint8_t> blob) const {
+    const uint blob_id = static_cast<uint>(blob_type);
+    if (blob_id > max_blob_id) {
         return StorageStatus::INVALID_ID;
     }
 
-    memcpy(&output, get_config_address(config_id), sizeof(config_t));
+    const uint8_t* blob_addr = get_blob_address(blob_id);
+    if (!blob_addr)
+        return StorageStatus::ERROR;
+
+    std::memcpy(blob.data(), blob_addr, blob.size());
 
     return StorageStatus::SUCCESS;
 }
 
-uint Storage::get_sector_id(uint config_id) const {
-    if (config_id > max_config_id) {
+StorageStatus Storage::_get_blob(uint blob_id, std::span<uint8_t> blob) const {
+    if (blob_id > max_blob_id) {
+        return StorageStatus::INVALID_ID;
+    }
+
+    const uint8_t* blob_addr = get_blob_address(blob_id);
+    if (!blob_addr)
+        return StorageStatus::ERROR;
+
+    std::memcpy(blob.data(), blob_addr, blob.size());
+
+    return StorageStatus::SUCCESS;
+}
+
+uint Storage::get_sector_id(BlobType blob_type) const {
+    const uint blob_id = static_cast<uint>(blob_type);
+    if (blob_id > max_blob_id) {
         return std::numeric_limits<unsigned int>::max();
     }
 
-    return config_id / configs_per_section;
+    return (blob_id / blobs_per_sector);
 }
 
 StorageStatus Storage::read_sector(uint sector_id) {
-    const uint start_config_id = sector_id * configs_per_section;
-
-    for (int i = 0; i < configs_per_section; i++) {
-        StorageStatus status = get_config(start_config_id + i, sector[i]);
+    const uint start_blob_id = sector_id * blobs_per_sector;
+    for (int i = 0; i < blobs_per_sector; i++) {
+        StorageStatus status = _get_blob(start_blob_id + i, sector[i]);
         if (status != StorageStatus::SUCCESS) {
             return status;
         }
@@ -61,18 +110,27 @@ StorageStatus Storage::read_sector(uint sector_id) {
     return StorageStatus::SUCCESS;
 }
 
-StorageStatus Storage::update_config_in_sector(uint config_id, config_t& config) {
-    if (config_id > max_config_id) {
+StorageStatus Storage::update_blob_in_sector(BlobType blob_type, std::span<uint8_t> blob) {
+    const uint blob_id = static_cast<uint>(blob_type);
+    if (blob_id > max_blob_id) {
         return StorageStatus::INVALID_ID;
     }
 
-    sector[config_id % configs_per_section] = config;
+    BlobBuff_t blob_copy{};
+    std::copy(blob.begin(), blob.end(), blob_copy.begin());
+
+    /* Fulfill rest of the sector with 0xFF */
+    if (blob.size() < BLOB_SLOT_SIZE_BYTES) {
+        std::memset(blob_copy.data() + blob.size(), 0xFF, BLOB_SLOT_SIZE_BYTES - blob.size());
+    }
+
+    sector[blob_id % blobs_per_sector] = std::move(blob_copy);
 
     return StorageStatus::SUCCESS;
 }
 
 void Storage::save_sector(uint sector_id) const {
-    if (sector.size() * sizeof(config_t) != FLASH_SECTOR_SIZE) {
+    if (sector.size() * BLOB_SLOT_SIZE_BYTES != FLASH_SECTOR_SIZE) {
         return;
     }
     const uintptr_t sector_addr = STORAGE_FLASH_OFFSET + (sector_id * FLASH_SECTOR_SIZE);
@@ -82,21 +140,22 @@ void Storage::save_sector(uint sector_id) const {
     restore_interrupts(interrupts);
 }
 
-StorageStatus Storage::save_config(uint config_id, config_t& config) {
+StorageStatus Storage::_save_blob(BlobType blob_type, std::span<uint8_t> blob) {
+    const uint blob_id   = static_cast<uint>(blob_type);
     StorageStatus status = StorageStatus::ERROR;
 
-    if (config_id > max_config_id) {
+    if (blob_id > max_blob_id) {
         return StorageStatus::INVALID_ID;
     }
 
-    uint sector_id = get_sector_id(config_id);
+    const uint sector_id = get_sector_id(blob_type);
 
     status = read_sector(sector_id);
     if (StorageStatus::SUCCESS != status) {
         return status;
     }
 
-    status = update_config_in_sector(config_id, config);
+    status = update_blob_in_sector(blob_type, blob);
     if (StorageStatus::SUCCESS != status) {
         return status;
     }


### PR DESCRIPTION
It now supports multiple config kinds. The BlobType enum is used to identify the blobs. Each structure must be lesser or equal to 1024 bytes.