### PR TITLE
Separate keys config and add parameters support in terminal

### DIFF
--- a/firmware/3-key.cpp
+++ b/firmware/3-key.cpp
@@ -41,7 +41,7 @@ int main(void) {
     g_leds    = &leds;
     multicore_launch_core1(leds_task_on_core1);
 
-    Terminal t(storage);
+    Terminal t(storage, keys);
     CdcDevice cdc(t);
 
     initialize_tud();

--- a/firmware/3-key.cpp
+++ b/firmware/3-key.cpp
@@ -4,6 +4,7 @@
 #include "cdc.hpp"
 #include "config.hpp"
 #include "hid.hpp"
+#include "keys_config.hpp"
 #include "leds.hpp"
 #include "storage.hpp"
 #include "terminal.hpp"
@@ -27,13 +28,13 @@ int main(void) {
     };
 
     Storage storage;
-
     storage.init();
 
-    Leds leds(key_configs.size());
+    KeysConfig keys(key_configs);
+    Leds leds(3, keys);
     leds.init();
 
-    Buttons buttons(key_configs);
+    Buttons buttons(keys);
     buttons.init();
 
     g_buttons = &buttons;

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -33,6 +33,7 @@ add_subdirectory(leds)
 add_subdirectory(usb)
 add_subdirectory(storage)
 add_subdirectory(terminal)
+add_subdirectory(keyscfg)
 
 target_link_libraries(${project_name} 
     pico_stdlib 
@@ -42,6 +43,7 @@ target_link_libraries(${project_name}
     usb
     storage 
     terminal
+    keyscfg
 )
 
 pico_add_extra_outputs(${project_name})

--- a/firmware/buttons/CMakeLists.txt
+++ b/firmware/buttons/CMakeLists.txt
@@ -10,4 +10,5 @@ target_link_libraries(${modulename}
     tinyusb_device
     usb
     leds
+    keyscfg
 )

--- a/firmware/buttons/buttons.cpp
+++ b/firmware/buttons/buttons.cpp
@@ -3,14 +3,10 @@
 #include <cstdint>
 #include <limits>
 
-Buttons::Buttons(const std::vector<ButtonConfig>& key_configs) {
-    for (const auto& config : key_configs) {
-        buttons[config.value] = config;
-    }
-}
+Buttons::Buttons(KeysConfig& keys) : keys(keys) {}
 
 void Buttons::init() {
-    for (const auto& [_, cfg] : buttons) {
+    for (const auto& cfg : keys.get_key_cfgs()) {
         gpio_init(cfg.gpio);
         gpio_set_dir(cfg.gpio, GPIO_IN);
         gpio_pull_up(cfg.gpio);
@@ -18,8 +14,8 @@ void Buttons::init() {
 }
 
 Key Buttons::get_pressed_key() const {
-    for (const auto& [key_or_modifier, cfg] : buttons) {
-        if (auto key = std::get_if<Key>(&key_or_modifier)) {
+    for (const auto& cfg : keys.get_key_cfgs()) {
+        if (auto key = std::get_if<Key>(&cfg.value)) {
             if (!gpio_get(cfg.gpio)) {
                 return *key;
             }
@@ -30,8 +26,8 @@ Key Buttons::get_pressed_key() const {
 
 uint8_t Buttons::get_modifier_flags() const {
     uint8_t modifier_flags = 0;
-    for (const auto& [key_or_modifier, cfg] : buttons) {
-        if (auto modifier = std::get_if<Modifier>(&key_or_modifier)) {
+    for (const auto& cfg : keys.get_key_cfgs()) {
+        if (auto modifier = std::get_if<Modifier>(&cfg.value)) {
             if (!gpio_get(cfg.gpio)) {
                 modifier_flags |= static_cast<uint8_t>(*modifier);
             }
@@ -41,33 +37,28 @@ uint8_t Buttons::get_modifier_flags() const {
 }
 
 uint Buttons::get_btn_id(const Button& btn) const {
-    auto it = buttons.find(btn);
-    if (it != buttons.end()) {
-        return it->second.id;
+    const auto& blobs = keys.get_key_cfgs();
+    for (const auto& cfg : blobs) {
+        if (cfg.value == btn) {
+            return cfg.id;
+        }
     }
     return std::numeric_limits<unsigned int>::max();
 }
 
 std::vector<Button> Buttons::get_btns() const {
     std::vector<Button> button_vector;
-    for (const auto& [key_or_modifier, _] : buttons) {
-        button_vector.push_back(key_or_modifier);
+    for (const auto& cfg : keys.get_key_cfgs()) {
+        button_vector.push_back(cfg.value);
     }
     return button_vector;
 }
 
 bool Buttons::is_btn_pressed(const Button& btn) const {
-    auto it = buttons.find(btn);
-    if (it != buttons.end()) {
-        return !gpio_get(it->second.gpio);
+    for (const auto& cfg : keys.get_key_cfgs()) {
+        if (cfg.value == btn && !gpio_get(cfg.gpio)) {
+            return true;
+        }
     }
     return false;
-}
-
-Color Buttons::get_btn_color(const Button& btn) const {
-    auto it = buttons.find(btn);
-    if (it != buttons.end()) {
-        return it->second.color;
-    }
-    return Color::None;
 }

--- a/firmware/buttons/include/buttons.hpp
+++ b/firmware/buttons/include/buttons.hpp
@@ -4,14 +4,15 @@
 #include <vector>
 
 #include "buttons_config.hpp"
+#include "keys_config.hpp"
 
 class Buttons {
   public:
-    explicit Buttons(const std::vector<ButtonConfig>& key_configs);
+    explicit Buttons(KeysConfig& keys);
     ~Buttons() = default;
 
   private:
-    std::map<Button, ButtonConfig> buttons;
+    KeysConfig& keys;
 
   public:
     void init();
@@ -20,5 +21,4 @@ class Buttons {
     uint8_t get_modifier_flags() const;
     uint get_btn_id(const Button& btn) const;
     std::vector<Button> get_btns() const;
-    Color get_btn_color(const Button& btn) const;
 };

--- a/firmware/keyscfg/CMakeLists.txt
+++ b/firmware/keyscfg/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(modulename "keyscfg")
+add_library(${modulename})
+target_include_directories(${modulename} PUBLIC include)
+target_link_libraries(${modulename}
+    pico_stdlib 
+    leds
+    buttons
+)

--- a/firmware/keyscfg/include/keys_config.hpp
+++ b/firmware/keyscfg/include/keys_config.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <vector>
+
+#include "buttons_config.hpp"
+#include "leds_config.hpp"
+#include "pico/stdlib.h"
+
+class KeysConfig {
+  public:
+    KeysConfig(std::vector<ButtonConfig> keys_default) : keys(keys_default) {
+        keys_cnt = keys_default.size();
+    };
+    ~KeysConfig() = default;
+
+  private:
+    std::vector<ButtonConfig> keys;
+    uint keys_cnt;
+
+  public:
+    const std::vector<ButtonConfig>& get_key_cfgs() const { return keys; }
+
+    uint get_keys_count() const { return keys_cnt; }
+
+    void set_key_color(uint key_id, Color color) {
+        if (key_id >= keys_cnt) {
+            return;
+        }
+        keys[key_id].color = color;
+    }
+
+    void set_key_value(uint key_id, Button btn) {
+        if (key_id >= keys_cnt) {
+            return;
+        }
+        keys[key_id].value = btn;
+    }
+
+    Color get_key_color(uint key_id) const {
+        if (key_id >= keys_cnt) {
+            return Color::None;
+        }
+        return keys[key_id].color;
+    }
+
+    Button get_key_value(uint key_id) const {
+        if (key_id >= keys_cnt) {
+            return Key::NONE;
+        }
+        return keys[key_id].value;
+    }
+};

--- a/firmware/leds/CMakeLists.txt
+++ b/firmware/leds/CMakeLists.txt
@@ -13,4 +13,5 @@ pico_generate_pio_header(${project_name} ${CMAKE_CURRENT_LIST_DIR}/include/ws281
 target_link_libraries(${modulename}
     hardware_pio 
     buttons
+    keyscfg
 )

--- a/firmware/leds/include/leds.hpp
+++ b/firmware/leds/include/leds.hpp
@@ -4,14 +4,17 @@
 
 #include "buttons.hpp"
 #include "hardware/pio.h"
+#include "keys_config.hpp"
 #include "leds_config.hpp"
 
 class Leds {
   public:
-    Leds(uint leds_count, PIO pio = pio0, uint pin = DEFAULT_LED_PIN, float freq = DEFAULT_FREQ);
+    Leds(uint leds_count, KeysConfig& keys, PIO pio = pio0, uint pin = DEFAULT_LED_PIN, float freq = DEFAULT_FREQ);
     ~Leds() = default;
 
   private:
+    KeysConfig& keys;
+
     uint leds_count;
     float w_freq;
     uint w_pin;
@@ -22,15 +25,16 @@ class Leds {
 
   public:
     void init();
-    void set_led_color(uint led_id, Color color, bool r = false);
-    void set_all_color(Color color, bool r = false);
-    void blink(uint led_id, Color color, uint count, float freq = 1);
-    void blink(Color color, uint count, float freq = 1);
-    void refresh();
+    void enable(uint led_id, bool r = false);
+    void disable(uint led_id, bool r = false);
+    void blink(uint led_id, uint count, float freq = 1);
+    void blink(uint count, float freq = 1);
+    void refresh() const;
+    void enable_all(bool r = false);
     void disable_all(bool r = false);
 
   private:
-    void push_led(const Led& led);
+    void push_led(const Led& led) const;
 };
 
 void leds_task(Leds& leds, const Buttons& buttons);

--- a/firmware/terminal/CMakeLists.txt
+++ b/firmware/terminal/CMakeLists.txt
@@ -7,4 +7,5 @@ target_include_directories(${modulename} PUBLIC include)
 target_link_libraries(${modulename}
         pico_stdlib
         storage
+        keyscfg
 )

--- a/firmware/terminal/include/terminal.hpp
+++ b/firmware/terminal/include/terminal.hpp
@@ -3,14 +3,14 @@
 #include <map>
 #include <string>
 
+#include "keys_config.hpp"
 #include "pico/stdlib.h"
 #include "storage.hpp"
 
 enum class Command {
     RESET,
-    SAVE,
-    READ,
     ERASE,
+    CHANGE_COLOR,
     UNKNOWN,
 };
 
@@ -19,28 +19,32 @@ class Terminal {
     static constexpr std::string start_string = "\r3-key>";
     static constexpr size_t max_chars         = 128;
     std::string buffer;
-    size_t buff_size_bytes;
     Storage& storage;
 
   public:
-    Terminal(Storage& storage);
+    Terminal(Storage& storage, KeysConfig& keys);
     ~Terminal() = default;
-    uint8_t* terminal(char new_char);
-    size_t get_buff_size() const;
+    std::span<uint8_t> terminal(char new_char);
 
   private:
+    KeysConfig& keys;
+
+    /* Command strings mapping */
     std::map<std::string, Command> command_map = {
         { "reset", Command::RESET },
-        { "save", Command::SAVE },
-        { "read", Command::READ },
         { "erase", Command::ERASE },
+        { "color", Command::CHANGE_COLOR },
     };
 
-    bool dispatch_command(Command command) const;
-    bool handle_command(const std::string& command_str) const;
+    bool dispatch_command(Command command, const std::vector<std::string>& params);
+    bool handle_command(const std::string& command_str);
     bool is_enter_pressed(char& ch) const;
     bool is_backspace_pressed(char& ch) const;
     bool is_new_valid_char(char& ch) const;
+    bool is_valid_number(const std::string& str) const;
+
+    void add_log(std::string log);
 
     void reset_to_bootloader() const;
+    bool handle_change_color_command(const std::vector<std::string>& params);
 };

--- a/firmware/terminal/terminal.cpp
+++ b/firmware/terminal/terminal.cpp
@@ -1,18 +1,20 @@
-#include "terminal.hpp"
+#include <algorithm>
+#include <limits>
+#include <span>
+#include <sstream>
+#include <vector>
+
+#include "keys_config.hpp"
 #include "pico/bootrom.h"
+#include "terminal.hpp"
 
 #define PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK 0u
 
-Terminal::Terminal(Storage& storage) : storage(storage) {
+Terminal::Terminal(Storage& storage, KeysConfig& keys) : storage(storage), keys(keys) {
     buffer += start_string;
-    buff_size_bytes = start_string.length();
 }
 
-size_t Terminal::get_buff_size() const {
-    return buff_size_bytes;
-}
-
-uint8_t* Terminal::terminal(char new_char) {
+std::span<uint8_t> Terminal::terminal(char new_char) {
     bool is_enter                    = is_enter_pressed(new_char);
     static std::string output_buffer = "";
 
@@ -23,21 +25,18 @@ uint8_t* Terminal::terminal(char new_char) {
     } else if (is_enter) {
         const std::string command = buffer.substr(start_string.length());
         buffer.clear();
-        if (!handle_command(command)) {
-            buffer += "\n\rUnsupported command";
-        }
+        (void)handle_command(command);
         buffer += "\n" + start_string;
     } else if (is_new_valid_char(new_char)) {
         buffer += new_char;
     }
 
-    output_buffer   = buffer;
-    buff_size_bytes = output_buffer.length();
+    output_buffer = buffer;
 
     if (is_enter)
         buffer = start_string;
 
-    return reinterpret_cast<uint8_t*>(output_buffer.data());
+    return std::span<uint8_t>(reinterpret_cast<uint8_t*>(output_buffer.data()), output_buffer.size());
 }
 
 bool Terminal::is_enter_pressed(char& ch) const {
@@ -52,34 +51,80 @@ bool Terminal::is_new_valid_char(char& ch) const {
     return (isprint(ch) && buffer.size() < max_chars + 6);
 }
 
-bool Terminal::handle_command(const std::string& command_str) const {
-    auto it           = command_map.find(command_str);
+bool Terminal::handle_command(const std::string& command_str) {
+    std::istringstream iss(command_str);
+    std::string command_name;
+    iss >> command_name;
+
+    std::vector<std::string> parameters;
+    std::string param;
+    while (iss >> param) {
+        parameters.push_back(param);
+    }
+
+    const auto it     = command_map.find(command_name);
     const Command cmd = (it != command_map.end()) ? it->second : Command::UNKNOWN;
-    return dispatch_command(cmd);
+    return dispatch_command(cmd, parameters);
 }
 
-bool Terminal::dispatch_command(Command command) const {
+bool Terminal::dispatch_command(Command command, const std::vector<std::string>& params) {
     switch (command) {
         case Command::RESET: {
             reset_to_bootloader();
             return true;
         }
-        case Command::SAVE: {
-            /* @TODO */
-            return true;
-        }
-        case Command::READ: {
-            /* @TODO */
-            return true;
-        }
         case Command::ERASE: {
             storage.erase();
+            add_log("Flash storage erased");
             return true;
+        }
+        case Command::CHANGE_COLOR: {
+            return handle_change_color_command(params);
         }
         default: return false;
     }
 }
 
+bool Terminal::is_valid_number(const std::string& str) const {
+    return !str.empty() && std::all_of(str.begin(), str.end(), ::isdigit);
+}
+
+bool Terminal::handle_change_color_command(const std::vector<std::string>& params) {
+    if (params.size() < 2) {
+        add_log("Error: change_color requires 2 parameters");
+        return false;
+    }
+
+    const std::string& button_id_str = params[0];
+    const uint button_id             = std::stoul(button_id_str);
+    if (!is_valid_number(button_id_str) || (button_id >= keys.get_keys_count())) {
+        add_log("Error: Invalid button ID");
+        return false;
+    }
+
+    const std::string& color_name = params[1];
+    Color color;
+    if (color_name == "red") {
+        color = Color::Red;
+    } else if (color_name == "green") {
+        color = Color::Green;
+    } else if (color_name == "blue") {
+        color = Color::Blue;
+    } else {
+        add_log("Error: Invalid color");
+        return false;
+    }
+
+    keys.set_key_color(button_id, color);
+    add_log("Changing button " + std::to_string(button_id) + " color to " + color_name);
+
+    return true;
+}
+
 void Terminal::reset_to_bootloader() const {
     reset_usb_boot(1u, PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK);
+}
+
+void Terminal::add_log(std::string log) {
+    buffer += "\r\n" + log;
 }

--- a/firmware/usb/cdc.cpp
+++ b/firmware/usb/cdc.cpp
@@ -3,10 +3,11 @@
 
 void CdcDevice::task() const {
     while (tud_cdc_available()) {
-        const char c        = tud_cdc_read_char();
-        const uint8_t* buff = t.terminal(c);
+        const char c = tud_cdc_read_char();
 
-        tud_cdc_write(buff, t.get_buff_size());
+        const std::span<uint8_t> buffer_span = t.terminal(c);
+
+        tud_cdc_write(buffer_span.data(), buffer_span.size());
         tud_cdc_write_flush();
     }
 }


### PR DESCRIPTION
**keyscfg: introduce KeysConfig module**

It configures the LEDs and buttons in the keyboard.
All other modules can modify the config thanks to
dependency injection.

**terminal: add CHANGE_COLOR command**

It introduces parameters support for commands.
CHANGE_COLOR command has the following format:

```
3-key>color <button_id> <color>
```
e.g.:
```
3-key>color 1 red
```

![3-key-change-color](https://github.com/user-attachments/assets/21e8bc26-84ba-4621-b41c-4598188e5935)
