### PR TITLE
Introduce Features Handler feature

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,145 @@
+# Features
+
+## Adding a New Feature to the Project
+This guide provides a step-by-step approach to add and integrate a new feature into the project. Each feature should be implemented as a module under the features directory.
+
+## Project Structure
+The `features` directory contains:
+
+- Individual `feature` modules, each in its own folder.
+- A `features_handler` module for managing and dispatching features.
+
+## Steps to Add a New Feature
+
+- Create a New Feature Directory
+    -  Navigate to the features directory.
+    - Create a new folder for the feature. For example, for a feature named new_feature, create:
+    ```bash
+    features/new_feature
+    ```
+    - Inside this folder, create the following: 
+        - A `CMakeLists.txt` file for the feature.
+        - A `new_feature.cpp` file containing the feature implementation.
+        - A include directory containing a header file, e.g., `new_feature.hpp`.
+
+- Define the `Feature` Class
+    - Define a new class that inherits from the Feature base class in `features_handler.hpp`.
+    - Implement the handle method for the feature's behavior.
+    - Example: `features/new_feature/include/new_feature.hpp`
+
+    ``` cpp
+    #pragma once
+
+    #include "features_handler.hpp"
+    #include "buttons.hpp"
+
+    class NewFeature : public Feature {
+    public:
+        void handle(const Buttons& buttons) override;
+    };
+    ```
+
+    - Example: `features/new_feature/new_feature.cpp`
+
+    ```cpp
+    #include "new_feature.hpp"
+
+    void NewFeature::handle(const Buttons& buttons) {
+        // Implement the feature-specific behavior here
+    }
+    ```
+
+- Update the `FeatureType` Enum
+    - Open `features_handler.hpp`.
+    - Add a new entry for the feature to the `FeatureType` enum.
+    - Example:
+
+    ```cpp
+    enum class FeatureType {
+        CTRL_C_V,
+        NEW_FEATURE, // Add your feature here
+        NONE,
+    };
+    ```
+
+- Register the Feature in `FeaturesHandler`
+    - Open `features_handler.cpp`.
+    - Update the init method to register the new feature.
+    - Example:
+
+    ```cpp
+    void FeaturesHandler::initialize_featuresinit() {
+        features[FeatureType::CTRL_C_V] = std::make_unique<CtrlCVFeature>(keys_config);
+        features[FeatureType::NEW_FEATURE] = std::make_unique<NewFeature>(keys_config);
+    }
+    ```
+
+- Integrate the Feature with the `Terminal`
+    - Open `terminal.cpp`.
+    - Update the handle_feature_command method to parse the new feature name and map it to `FeatureType`.
+    - Example:
+
+    ```cpp
+    bool Terminal::handle_feature_command(const std::vector<std::string>& params) {
+        if (params.size() != 1) {
+            add_log("Error: feature requires exactly 1 parameter");
+            return false;
+        }
+
+        const std::string& feature_name = params[0];
+        FeatureType feature;
+
+        if (feature_name == "ctrl_c_v") {
+            feature = FeatureType::CTRL_C_V;
+        } else if (feature_name == "new_feature") { // Add parsing logic
+            feature = FeatureType::NEW_FEATURE;
+        } else {
+            add_log("Error: Unknown feature");
+            return false;
+        }
+
+        add_log("Feature enabled: " + feature_name);
+
+        // Logic to switch to the feature
+        features_handler.switch_to_feature(feature);
+
+        return true;
+    }
+    ```
+
+- Create the Feature’s `CMakeLists.txt`
+    - Example: `features/new_feature/CMakeLists.txt`
+
+    ```cmake
+    # Define the new feature module
+    add_library(new_feature STATIC new_feature.cpp)
+
+    # Include the necessary directories
+    target_include_directories(new_feature PUBLIC include)
+
+    # Link dependencies
+    target_link_libraries(new_feature PUBLIC features_handler)
+    ```
+
+- Update the Parent `CMakeLists.txt`
+    - Open `features/CMakeLists.txt`.
+    - Add the new feature module.
+    - Example:
+
+    ```cmake
+    add_subdirectory(ctrl_c_v)
+    add_subdirectory(new_feature) # Add your new feature here
+    ```
+
+- Test the Feature
+    - Build the project using the top-level CMakeLists.txt.
+    - Test the new feature using the terminal interface by executing the command:
+    ``` php
+    feature <feature_name>
+    ```
+    - Replace <feature_name> with the feature name, e.g., new_feature.
+
+- Future Expansion
+    - To add more features, repeat the steps above for each new feature.
+    - Use the `FeatureType` enum and `FeaturesHandler` to manage feature-specific behavior efficiently.
+

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -36,6 +36,7 @@ add_subdirectory(usb)
 add_subdirectory(storage)
 add_subdirectory(terminal)
 add_subdirectory(keyscfg)
+add_subdirectory(features)
 
 target_link_libraries(${project_name} 
     pico_stdlib 
@@ -46,6 +47,7 @@ target_link_libraries(${project_name}
     storage 
     terminal
     keyscfg
+    features_handler
 )
 
 pico_add_extra_outputs(${project_name})

--- a/firmware/features/CMakeLists.txt
+++ b/firmware/features/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(features_handler)
+add_subdirectory(ctrl_c_v)

--- a/firmware/features/ctrl_c_v/CMakeLists.txt
+++ b/firmware/features/ctrl_c_v/CMakeLists.txt
@@ -1,12 +1,11 @@
-set(modulename "terminal")
+set(modulename "ctrl_c_v")
 set(SOURCES 
-        terminal.cpp
+        ctrl_c_v.cpp
 )
 add_library(${modulename} ${SOURCES})
 target_include_directories(${modulename} PUBLIC include)
 target_link_libraries(${modulename}
-        pico_stdlib
-        storage
-        keyscfg
-        features_handler
+    pico_stdlib 
+    features_handler
+    usb
 )

--- a/firmware/features/ctrl_c_v/ctrl_c_v.cpp
+++ b/firmware/features/ctrl_c_v/ctrl_c_v.cpp
@@ -1,0 +1,61 @@
+/*
+ * 3-key Project
+ *
+ * This file is part of the 3-key project.
+ *
+ * Copyright (C) 2025 Dominik Trochowski <dominik.trochowski@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ctrl_c_v.hpp"
+#include "keys_config.hpp"
+#include "tusb.h"
+#include "usb_descriptors.h"
+
+void CtrlCVFeature::init() {
+    const std::vector<KeyConfigTableEntry_t> keys = {
+        { 0, Key::V, Color::Red },
+        { 1, Key::C, Color::Green },
+        { 2, Modifier::LEFT_CMD, Color::Blue },
+    };
+
+    for (const auto& entry : keys) {
+        keys_config.set_key_color(entry.id, entry.color);
+        keys_config.set_key_value(entry.id, entry.key);
+    }
+}
+
+void CtrlCVFeature::send_keys(const uint8_t key, const Buttons& buttons) {
+    if (!tud_hid_ready())
+        return;
+
+    if (key) {
+        uint8_t keycode[6]     = {};
+        keycode[0]             = key;
+        const uint8_t modifier = buttons.get_modifier_flags();
+
+        tud_hid_keyboard_report(REPORT_ID_KEYBOARD, modifier, keycode);
+        has_keyboard_key = true;
+    } else {
+        if (has_keyboard_key)
+            tud_hid_keyboard_report(REPORT_ID_KEYBOARD, 0, NULL);
+        has_keyboard_key = false;
+    }
+}
+
+void CtrlCVFeature::handle(const Buttons& buttons) {
+    const uint8_t key = buttons.get_pressed_key();
+    send_keys(key, buttons);
+}

--- a/firmware/features/ctrl_c_v/include/ctrl_c_v.hpp
+++ b/firmware/features/ctrl_c_v/include/ctrl_c_v.hpp
@@ -21,24 +21,18 @@
 
 #pragma once
 
-#include "hardware/flash.h"
+#include "buttons.hpp"
+#include "features_handler.hpp"
 
-#define BLOB_SLOTS_COUNT 16
-#define BLOB_SLOT_SIZE_BYTES 2048
-#define BLOB_MAGIC 0xDEADBEEF
+class CtrlCVFeature : public Feature {
+  public:
+    explicit CtrlCVFeature(KeysConfig& keys_config)
+    : Feature(keys_config), has_keyboard_key(false) {}
+    void handle(const Buttons& buttons);
 
-#define STORAGE_SIZE (BLOB_SLOTS_COUNT * BLOB_SLOT_SIZE_BYTES)
-static_assert((STORAGE_SIZE % FLASH_SECTOR_SIZE) == 0, "The size of the storage must be multiple of sector size.");
+  private:
+    bool has_keyboard_key;
 
-#define STORAGE_FLASH_OFFSET (PICO_FLASH_SIZE_BYTES - STORAGE_SIZE)
-
-typedef struct {
-    uint32_t magic;
-    uint32_t init_count;
-} StorageConfig_t;
-
-enum class BlobType : uint {
-    STORAGE_CONFIG,
-    FEATURES_HANDLER_CONFIG,
-    BLOBS_COUNT,
+    void send_keys(const uint8_t key, const Buttons& buttons);
+    void init();
 };

--- a/firmware/features/features_handler/CMakeLists.txt
+++ b/firmware/features/features_handler/CMakeLists.txt
@@ -1,12 +1,11 @@
-set(modulename "terminal")
+set(modulename "features_handler")
 set(SOURCES 
-        terminal.cpp
+        features_handler.cpp
 )
 add_library(${modulename} ${SOURCES})
 target_include_directories(${modulename} PUBLIC include)
 target_link_libraries(${modulename}
-        pico_stdlib
-        storage
-        keyscfg
-        features_handler
+    pico_stdlib 
+    buttons
+    ctrl_c_v
 )

--- a/firmware/features/features_handler/features_handler.cpp
+++ b/firmware/features/features_handler/features_handler.cpp
@@ -1,0 +1,81 @@
+/*
+ * 3-key Project
+ *
+ * This file is part of the 3-key project.
+ *
+ * Copyright (C) 2025 Dominik Trochowski <dominik.trochowski@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "features_handler.hpp"
+#include "features.hpp"
+#include "keys_config.hpp"
+#include "storage.hpp"
+
+FeaturesHandler::FeaturesHandler(Storage& storage, KeysConfig& keys_config)
+: storage(storage), keys_config(keys_config) {}
+
+void FeaturesHandler::init() {
+    (void)storage.get_blob(BlobType::FEATURES_HANDLER_CONFIG, config);
+
+    initialize_features();
+
+    if (is_factory_required()) {
+        factory_init();
+    }
+}
+
+void FeaturesHandler::initialize_features() {
+    features[FeatureType::CTRL_C_V] = std::make_unique<CtrlCVFeature>(keys_config);
+}
+
+void FeaturesHandler::factory_init() {
+    config.magic = BLOB_MAGIC;
+    /* Setting default feature */
+    switch_to_feature(FeatureType::CTRL_C_V);
+    (void)storage.save_blob(BlobType::FEATURES_HANDLER_CONFIG, config);
+}
+
+bool FeaturesHandler::is_factory_required() const {
+    return (config.magic != BLOB_MAGIC);
+}
+
+void FeaturesHandler::switch_to_feature(FeatureType type) {
+    FeaturesHandlerConfig_t conifg_cpy = config;
+
+    config.is_feature_set  = (type == FeatureType::NONE) ? false : true;
+    config.current_feature = type;
+
+    if ((features.find(type) == features.end()) && (type != FeatureType::NONE)) {
+        config = conifg_cpy;
+        return;
+    }
+
+    if (type != FeatureType::NONE)
+        features[type]->init();
+
+    (void)storage.save_blob(BlobType::FEATURES_HANDLER_CONFIG, config);
+}
+
+void FeaturesHandler::handle(const Buttons& buttons) {
+    if (!config.is_feature_set)
+        return;
+
+    auto it = features.find(config.current_feature);
+    if (it == features.end())
+        return;
+
+    it->second->handle(buttons);
+}

--- a/firmware/features/features_handler/include/features.hpp
+++ b/firmware/features/features_handler/include/features.hpp
@@ -21,24 +21,4 @@
 
 #pragma once
 
-#include "hardware/flash.h"
-
-#define BLOB_SLOTS_COUNT 16
-#define BLOB_SLOT_SIZE_BYTES 2048
-#define BLOB_MAGIC 0xDEADBEEF
-
-#define STORAGE_SIZE (BLOB_SLOTS_COUNT * BLOB_SLOT_SIZE_BYTES)
-static_assert((STORAGE_SIZE % FLASH_SECTOR_SIZE) == 0, "The size of the storage must be multiple of sector size.");
-
-#define STORAGE_FLASH_OFFSET (PICO_FLASH_SIZE_BYTES - STORAGE_SIZE)
-
-typedef struct {
-    uint32_t magic;
-    uint32_t init_count;
-} StorageConfig_t;
-
-enum class BlobType : uint {
-    STORAGE_CONFIG,
-    FEATURES_HANDLER_CONFIG,
-    BLOBS_COUNT,
-};
+#include "ctrl_c_v.hpp"

--- a/firmware/features/features_handler/include/features_handler.hpp
+++ b/firmware/features/features_handler/include/features_handler.hpp
@@ -1,0 +1,73 @@
+/*
+ * 3-key Project
+ *
+ * This file is part of the 3-key project.
+ *
+ * Copyright (C) 2025 Dominik Trochowski <dominik.trochowski@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "buttons.hpp"
+#include "keys_config.hpp"
+#include "storage.hpp"
+
+#include <memory>
+#include <unordered_map>
+
+enum class FeatureType {
+    CTRL_C_V,
+    NONE,
+};
+
+typedef struct {
+    uint32_t magic;
+    FeatureType current_feature;
+    bool is_feature_set;
+} FeaturesHandlerConfig_t;
+
+class Feature {
+  public:
+    explicit Feature(KeysConfig& keys_config) : keys_config(keys_config) {}
+    virtual ~Feature() = default;
+
+    // Called on each HID task loop
+    virtual void handle(const Buttons& buttons) = 0;
+    virtual void init()                         = 0;
+
+  protected:
+    KeysConfig& keys_config;
+};
+
+class FeaturesHandler {
+  public:
+    FeaturesHandler(Storage& storage, KeysConfig& keys_config);
+    ~FeaturesHandler() = default;
+
+    void init();
+    void factory_init();
+    void switch_to_feature(FeatureType type);
+    void handle(const Buttons& buttons);
+
+  private:
+    FeaturesHandlerConfig_t config;
+    Storage& storage;
+    std::unordered_map<FeatureType, std::unique_ptr<Feature>> features;
+    KeysConfig& keys_config;
+
+    void initialize_features();
+    bool is_factory_required() const;
+};

--- a/firmware/keyscfg/include/keys_config.hpp
+++ b/firmware/keyscfg/include/keys_config.hpp
@@ -25,11 +25,19 @@
 
 #include "buttons_config.hpp"
 #include "leds_config.hpp"
+#include "pico/mutex.h"
 #include "pico/stdlib.h"
+
+typedef struct {
+    uint id;
+    Button key;
+    Color color;
+} KeyConfigTableEntry_t;
 
 class KeysConfig {
   public:
-    KeysConfig(std::vector<ButtonConfig> keys_default) : keys(keys_default) {
+    KeysConfig(std::vector<ButtonConfig> keys_default, mutex_t& mutex)
+    : keys(keys_default), mutex(mutex) {
         keys_cnt = keys_default.size();
     };
     ~KeysConfig() = default;
@@ -37,6 +45,7 @@ class KeysConfig {
   private:
     std::vector<ButtonConfig> keys;
     uint keys_cnt;
+    mutex_t& mutex;
 
   public:
     const std::vector<ButtonConfig>& get_key_cfgs() const { return keys; }
@@ -47,14 +56,18 @@ class KeysConfig {
         if (key_id >= keys_cnt) {
             return;
         }
+        mutex_enter_blocking(&mutex);
         keys[key_id].color = color;
+        mutex_exit(&mutex);
     }
 
     void set_key_value(uint key_id, Button btn) {
         if (key_id >= keys_cnt) {
             return;
         }
+        mutex_enter_blocking(&mutex);
         keys[key_id].value = btn;
+        mutex_exit(&mutex);
     }
 
     Color get_key_color(uint key_id) const {

--- a/firmware/storage/include/storage.hpp
+++ b/firmware/storage/include/storage.hpp
@@ -27,6 +27,7 @@
 
 #include "hardware/flash.h"
 #include "hardware/sync.h"
+#include "pico/mutex.h"
 
 #include "storage_config.hpp"
 
@@ -41,7 +42,7 @@ using BlobBuff_t = std::array<uint8_t, BLOB_SLOT_SIZE_BYTES>;
 
 class Storage {
   public:
-    Storage();
+    Storage(mutex_t& mutex);
     ~Storage() = default;
     StorageStatus init();
     StorageStatus factory_init();
@@ -52,6 +53,7 @@ class Storage {
     std::vector<BlobBuff_t> sector;
     uint32_t max_blob_id;
     const uint8_t* storage_start_addr;
+    mutex_t& mutex;
 
     const uint8_t* get_blob_address(uint blob_id) const;
     uint get_sector_id(BlobType blob_type) const;

--- a/firmware/terminal/include/terminal.hpp
+++ b/firmware/terminal/include/terminal.hpp
@@ -23,7 +23,9 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
+#include "features_handler.hpp"
 #include "keys_config.hpp"
 #include "pico/stdlib.h"
 #include "storage.hpp"
@@ -32,6 +34,7 @@ enum class Command {
     RESET,
     ERASE,
     CHANGE_COLOR,
+    FEATURE,
     UNKNOWN,
 };
 
@@ -43,18 +46,20 @@ class Terminal {
     Storage& storage;
 
   public:
-    Terminal(Storage& storage, KeysConfig& keys);
+    Terminal(Storage& storage, KeysConfig& keys, FeaturesHandler& f_handler);
     ~Terminal() = default;
     std::span<uint8_t> terminal(char new_char);
 
   private:
     KeysConfig& keys;
+    FeaturesHandler& f_handler;
 
     /* Command strings mapping */
     std::map<std::string, Command> command_map = {
         { "reset", Command::RESET },
         { "erase", Command::ERASE },
         { "color", Command::CHANGE_COLOR },
+        { "feature", Command::FEATURE },
     };
 
     bool dispatch_command(Command command, const std::vector<std::string>& params);
@@ -68,4 +73,5 @@ class Terminal {
 
     void reset_to_bootloader() const;
     bool handle_change_color_command(const std::vector<std::string>& params);
+    bool handle_feature_command(const std::vector<std::string>& params);
 };

--- a/firmware/usb/CMakeLists.txt
+++ b/firmware/usb/CMakeLists.txt
@@ -13,4 +13,5 @@ target_link_libraries(${modulename}
     tinyusb_board
     buttons
     terminal
+    features_handler
 )

--- a/firmware/usb/hid.cpp
+++ b/firmware/usb/hid.cpp
@@ -23,33 +23,10 @@
 
 #include "buttons.hpp"
 #include "buttons_config.hpp"
+#include "hid.hpp"
 #include "usb_descriptors.h"
 
-static void send_hid_report(uint8_t report_id, uint8_t key, const Buttons& buttons) {
-    if (!tud_hid_ready())
-        return;
-
-    if (report_id == REPORT_ID_KEYBOARD) {
-        // use to avoid send multiple consecutive zero report for keyboard
-        static bool has_keyboard_key = false;
-
-        if (key) {
-            uint8_t keycode[6]     = {};
-            keycode[0]             = key;
-            const uint8_t modifier = buttons.get_modifier_flags();
-
-            tud_hid_keyboard_report(REPORT_ID_KEYBOARD, modifier, keycode);
-            has_keyboard_key = true;
-        } else {
-            // send empty key report if previously has key pressed
-            if (has_keyboard_key)
-                tud_hid_keyboard_report(REPORT_ID_KEYBOARD, 0, NULL);
-            has_keyboard_key = false;
-        }
-    }
-}
-
-void hid_task(const Buttons& buttons) {
+void hid_task(const Buttons& buttons, FeaturesHandler& features_handler) {
     constexpr uint32_t interval_ms = 10;
     static uint32_t start_ms       = 0;
 
@@ -57,13 +34,7 @@ void hid_task(const Buttons& buttons) {
         return;
     start_ms += interval_ms;
 
-    const uint32_t key = buttons.get_pressed_key();
-
-    if (tud_suspended() && (key != Key::NONE)) {
-        tud_remote_wakeup();
-    } else {
-        send_hid_report(REPORT_ID_KEYBOARD, key, buttons);
-    }
+    features_handler.handle(buttons);
 }
 
 void tud_hid_report_complete_cb(uint8_t instance, uint8_t const* report, uint16_t len) {

--- a/firmware/usb/include/hid.hpp
+++ b/firmware/usb/include/hid.hpp
@@ -22,5 +22,6 @@
 #pragma once
 
 #include "buttons.hpp"
+#include "features_handler.hpp"
 
-void hid_task(const Buttons& buttons);
+void hid_task(const Buttons& buttons, FeaturesHandler& features_handler);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,8 @@ plugins:
 nav:
   - Home: index.md
   - Hardware: hardware.md
-  - Development: development.md
+  - Development:
+      - Environment & Tools: development.md
+      - Features: features.md
   - Blog: blog/index.md
 exclude_docs: README.md


### PR DESCRIPTION
**features-handler: introduce module for handling features**

The module will handle changing current enabled feature.
It uses flash memory to store config. Changing the
features is introduced through terminal:
```
3-key>feature <feature_name>
```
For the beginning only the basic ctrl_c_v feature is implemented.
All other features can be implemented in a similar way.

**doc: update documentation with features_handler description**

The newly created features.md page explains how to add
new feature.