### PR TITLE
keys_config: add persistent storage for KeysConfig module

### DIFF
--- a/firmware/3-key.cpp
+++ b/firmware/3-key.cpp
@@ -59,7 +59,7 @@ int main(void) {
     Storage storage(g_mutex);
     storage.init();
 
-    KeysConfig keys(key_configs, g_mutex);
+    KeysConfig keys(key_configs, storage);
     Leds leds(3, keys);
     leds.init();
 

--- a/firmware/keyscfg/CMakeLists.txt
+++ b/firmware/keyscfg/CMakeLists.txt
@@ -5,4 +5,5 @@ target_link_libraries(${modulename}
     pico_stdlib 
     leds
     buttons
+    storage
 )

--- a/firmware/storage/include/storage_config.hpp
+++ b/firmware/storage/include/storage_config.hpp
@@ -40,5 +40,6 @@ typedef struct {
 enum class BlobType : uint {
     STORAGE_CONFIG,
     FEATURES_HANDLER_CONFIG,
+    KEYS_CONFIG,
     BLOBS_COUNT,
 };


### PR DESCRIPTION
The keys configuration (colors and key values) are now being stored in persistent storage, so any configuration modification will stay unmodified after power cycle.