### PR TITLE
time-tracker: introduce 'time-tracker' feature for tracking work and meetings time

### DIFF
--- a/firmware/buttons/buttons.cpp
+++ b/firmware/buttons/buttons.cpp
@@ -34,13 +34,13 @@ Buttons::Buttons(KeysConfig& keys) : keys(keys) {}
 
 void Buttons::init() {
     for (const auto& cfg : keys.get_key_cfgs()) {
-        setup_button(cfg.gpio, cfg.id);
+        setup_button(cfg.gpio, cfg.button_id);
     }
 }
 
 Key Buttons::get_pressed_key() const {
     for (const auto& cfg : keys.get_key_cfgs()) {
-        if (auto key = std::get_if<Key>(&cfg.value)) {
+        if (auto key = std::get_if<Key>(&cfg.key_value)) {
             if (!gpio_get(cfg.gpio)) {
                 return *key;
             }
@@ -52,7 +52,7 @@ Key Buttons::get_pressed_key() const {
 uint Buttons::get_pressed_key_id() const {
     for (const auto& cfg : keys.get_key_cfgs()) {
         if (!gpio_get(cfg.gpio)) {
-            return cfg.id;
+            return cfg.button_id;
         }
     }
     return std::numeric_limits<unsigned int>::max();
@@ -61,7 +61,7 @@ uint Buttons::get_pressed_key_id() const {
 uint8_t Buttons::get_modifier_flags() const {
     uint8_t modifier_flags = 0;
     for (const auto& cfg : keys.get_key_cfgs()) {
-        if (auto modifier = std::get_if<Modifier>(&cfg.value)) {
+        if (auto modifier = std::get_if<Modifier>(&cfg.key_value)) {
             if (!gpio_get(cfg.gpio)) {
                 modifier_flags |= static_cast<uint8_t>(*modifier);
             }
@@ -73,8 +73,8 @@ uint8_t Buttons::get_modifier_flags() const {
 uint Buttons::get_btn_id(const Button& btn) const {
     const auto& blobs = keys.get_key_cfgs();
     for (const auto& cfg : blobs) {
-        if (cfg.value == btn) {
-            return cfg.id;
+        if (cfg.key_value == btn) {
+            return cfg.button_id;
         }
     }
     return std::numeric_limits<unsigned int>::max();
@@ -83,14 +83,14 @@ uint Buttons::get_btn_id(const Button& btn) const {
 std::vector<Button> Buttons::get_btns() const {
     std::vector<Button> button_vector;
     for (const auto& cfg : keys.get_key_cfgs()) {
-        button_vector.push_back(cfg.value);
+        button_vector.push_back(cfg.key_value);
     }
     return button_vector;
 }
 
 bool Buttons::is_btn_pressed(const Button& btn) const {
     for (const auto& cfg : keys.get_key_cfgs()) {
-        if (cfg.value == btn && !gpio_get(cfg.gpio)) {
+        if (cfg.key_value == btn && !gpio_get(cfg.gpio)) {
             return true;
         }
     }

--- a/firmware/buttons/buttons.cpp
+++ b/firmware/buttons/buttons.cpp
@@ -24,6 +24,9 @@
 #include <cstdint>
 #include <limits>
 
+static bool debounce_timer_callback(repeating_timer_t* timer);
+static uint get_key_id(uint gpio);
+
 /*     key_id, button_state  */
 std::map<uint, ButtonState_t> button_map;
 
@@ -117,7 +120,7 @@ void Buttons::clear_pending(uint key_id) {
     state.is_pending_handle = false;
 }
 
-uint get_key_id(uint gpio) {
+static uint get_key_id(uint gpio) {
     for (const auto& [key_id, button_state] : button_map) {
         if (button_state.gpio == gpio) {
             return key_id;
@@ -142,7 +145,7 @@ void gpio_callback(uint gpio, uint32_t events) {
     }
 }
 
-bool debounce_timer_callback(repeating_timer_t* timer) {
+static bool debounce_timer_callback(repeating_timer_t* timer) {
     const uint gpio      = (uint)(uintptr_t)timer->user_data;
     ButtonState_t& state = button_map[get_key_id(gpio)];
 

--- a/firmware/buttons/include/buttons.hpp
+++ b/firmware/buttons/include/buttons.hpp
@@ -22,10 +22,19 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <vector>
 
 #include "buttons_config.hpp"
 #include "keys_config.hpp"
+
+constexpr uint DEBOUNCE_DELAY_MS = 200;
+
+typedef struct {
+    bool is_debouncing;
+    bool is_pending_handle;
+    uint gpio;
+} ButtonState_t;
 
 class Buttons {
   public:
@@ -39,7 +48,12 @@ class Buttons {
     void init();
     bool is_btn_pressed(const Button& btn) const;
     Key get_pressed_key() const;
+    uint get_pressed_key_id() const;
     uint8_t get_modifier_flags() const;
     uint get_btn_id(const Button& btn) const;
     std::vector<Button> get_btns() const;
+    void setup_button(uint gpio, uint key_id);
+
+    void clear_pending(uint key_id);
+    std::optional<uint> get_pending_button();
 };

--- a/firmware/buttons/include/buttons_config.hpp
+++ b/firmware/buttons/include/buttons_config.hpp
@@ -41,9 +41,9 @@ enum Modifier : uint8_t {
 using Button = std::variant<Key, Modifier>;
 
 struct ButtonConfig {
-    uint id;
+    uint button_id;
     uint gpio;
-    Button value;
+    Button key_value;
     Color color;
     bool enabled;
 };

--- a/firmware/buttons/include/buttons_config.hpp
+++ b/firmware/buttons/include/buttons_config.hpp
@@ -45,4 +45,5 @@ struct ButtonConfig {
     uint gpio;
     Button value;
     Color color;
+    bool enabled;
 };

--- a/firmware/buttons/include/buttons_interrupt.hpp
+++ b/firmware/buttons/include/buttons_interrupt.hpp
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include "buttons.hpp"
-#include "features_handler.hpp"
-
-void hid_task(Buttons& buttons, FeaturesHandler& features_handler);
+void gpio_callback(uint gpio, uint32_t events);
+bool debounce_timer_callback(repeating_timer_t* timer);
+uint get_key_id(uint gpio);

--- a/firmware/buttons/include/buttons_interrupt.hpp
+++ b/firmware/buttons/include/buttons_interrupt.hpp
@@ -22,5 +22,3 @@
 #pragma once
 
 void gpio_callback(uint gpio, uint32_t events);
-bool debounce_timer_callback(repeating_timer_t* timer);
-uint get_key_id(uint gpio);

--- a/firmware/features/CMakeLists.txt
+++ b/firmware/features/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(features_handler)
 add_subdirectory(ctrl_c_v)
+add_subdirectory(time_tracker)

--- a/firmware/features/ctrl_c_v/ctrl_c_v.cpp
+++ b/firmware/features/ctrl_c_v/ctrl_c_v.cpp
@@ -26,14 +26,15 @@
 
 void CtrlCVFeature::init() {
     const std::vector<KeyConfigTableEntry_t> keys = {
+        /* key_id key_value color */
         { 0, Key::V, Color::Red },
         { 1, Key::C, Color::Green },
         { 2, Modifier::LEFT_CMD, Color::Blue },
     };
 
     for (const auto& entry : keys) {
-        keys_config.set_key_color(entry.id, entry.color);
-        keys_config.set_key_value(entry.id, entry.key);
+        keys_config.set_key_color(entry.key_id, entry.color);
+        keys_config.set_key_value(entry.key_id, entry.key);
     }
 
     keys_config.switch_leds_mode(LedsMode::WHEN_BUTTON_PRESSED);

--- a/firmware/features/ctrl_c_v/ctrl_c_v.cpp
+++ b/firmware/features/ctrl_c_v/ctrl_c_v.cpp
@@ -35,6 +35,8 @@ void CtrlCVFeature::init() {
         keys_config.set_key_color(entry.id, entry.color);
         keys_config.set_key_value(entry.id, entry.key);
     }
+
+    keys_config.switch_leds_mode(LedsMode::WHEN_BUTTON_PRESSED);
 }
 
 void CtrlCVFeature::send_keys(const uint8_t key, const Buttons& buttons) {
@@ -55,7 +57,11 @@ void CtrlCVFeature::send_keys(const uint8_t key, const Buttons& buttons) {
     }
 }
 
-void CtrlCVFeature::handle(const Buttons& buttons) {
+void CtrlCVFeature::handle(Buttons& buttons) {
     const uint8_t key = buttons.get_pressed_key();
     send_keys(key, buttons);
+}
+
+std::string CtrlCVFeature::get_log(uint log_id) const {
+    return "";
 }

--- a/firmware/features/ctrl_c_v/include/ctrl_c_v.hpp
+++ b/firmware/features/ctrl_c_v/include/ctrl_c_v.hpp
@@ -28,11 +28,12 @@ class CtrlCVFeature : public Feature {
   public:
     explicit CtrlCVFeature(KeysConfig& keys_config)
     : Feature(keys_config), has_keyboard_key(false) {}
-    void handle(const Buttons& buttons);
+    void handle(Buttons& buttons);
 
   private:
     bool has_keyboard_key;
 
     void send_keys(const uint8_t key, const Buttons& buttons);
     void init();
+    std::string get_log(uint log_id) const;
 };

--- a/firmware/features/features_handler/features_handler.cpp
+++ b/firmware/features/features_handler/features_handler.cpp
@@ -35,10 +35,14 @@ void FeaturesHandler::init() {
     if (is_factory_required()) {
         factory_init();
     }
+
+    if (config.is_feature_set)
+        features[config.current_feature]->init();
 }
 
 void FeaturesHandler::initialize_features() {
-    features[FeatureType::CTRL_C_V] = std::make_unique<CtrlCVFeature>(keys_config);
+    features[FeatureType::CTRL_C_V]     = std::make_unique<CtrlCVFeature>(keys_config);
+    features[FeatureType::TIME_TRACKER] = std::make_unique<TimeTracker>(keys_config, storage);
 }
 
 void FeaturesHandler::factory_init() {

--- a/firmware/features/features_handler/features_handler.cpp
+++ b/firmware/features/features_handler/features_handler.cpp
@@ -69,7 +69,7 @@ void FeaturesHandler::switch_to_feature(FeatureType type) {
     (void)storage.save_blob(BlobType::FEATURES_HANDLER_CONFIG, config);
 }
 
-void FeaturesHandler::handle(const Buttons& buttons) {
+void FeaturesHandler::handle(Buttons& buttons) {
     if (!config.is_feature_set)
         return;
 
@@ -78,4 +78,9 @@ void FeaturesHandler::handle(const Buttons& buttons) {
         return;
 
     it->second->handle(buttons);
+}
+
+std::string FeaturesHandler::get_feature_log(FeatureType f_type, uint log_id) const {
+    const auto& feature = features.at(f_type);
+    return feature->get_log(log_id);
 }

--- a/firmware/features/features_handler/include/features.hpp
+++ b/firmware/features/features_handler/include/features.hpp
@@ -22,3 +22,4 @@
 #pragma once
 
 #include "ctrl_c_v.hpp"
+#include "time_tracker.hpp"

--- a/firmware/features/features_handler/include/features_handler.hpp
+++ b/firmware/features/features_handler/include/features_handler.hpp
@@ -45,8 +45,9 @@ class Feature {
     virtual ~Feature() = default;
 
     // Called on each HID task loop
-    virtual void handle(const Buttons& buttons) = 0;
-    virtual void init()                         = 0;
+    virtual void handle(Buttons& buttons)          = 0;
+    virtual void init()                            = 0;
+    virtual std::string get_log(uint log_id) const = 0;
 
   protected:
     KeysConfig& keys_config;
@@ -60,7 +61,8 @@ class FeaturesHandler {
     void init();
     void factory_init();
     void switch_to_feature(FeatureType type);
-    void handle(const Buttons& buttons);
+    void handle(Buttons& buttons);
+    std::string get_feature_log(FeatureType f_type, uint log_id) const;
 
   private:
     FeaturesHandlerConfig_t config;

--- a/firmware/features/features_handler/include/features_handler.hpp
+++ b/firmware/features/features_handler/include/features_handler.hpp
@@ -30,6 +30,7 @@
 
 enum class FeatureType {
     CTRL_C_V,
+    TIME_TRACKER,
     NONE,
 };
 

--- a/firmware/features/time_tracker/CMakeLists.txt
+++ b/firmware/features/time_tracker/CMakeLists.txt
@@ -1,12 +1,11 @@
-set(modulename "features_handler")
+set(modulename "time_tracker")
 set(SOURCES 
-        features_handler.cpp
+        time_tracker.cpp
 )
 add_library(${modulename} ${SOURCES})
 target_include_directories(${modulename} PUBLIC include)
 target_link_libraries(${modulename}
     pico_stdlib 
-    buttons
-    ctrl_c_v
-    time_tracker
+    features_handler
+    usb
 )

--- a/firmware/features/time_tracker/include/time_tracker.hpp
+++ b/firmware/features/time_tracker/include/time_tracker.hpp
@@ -1,0 +1,61 @@
+/*
+ * 3-key Project
+ *
+ * This file is part of the 3-key project.
+ *
+ * Copyright (C) 2025 Dominik Trochowski <dominik.trochowski@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "buttons.hpp"
+#include "features_handler.hpp"
+
+#include "pico/stdlib.h"
+
+#define MAX_TIME_TRACKER_ENTRIES_COUNT 31
+
+typedef struct {
+    uint64_t start_time_us;
+    uint64_t work_time_us;
+    uint64_t meeting_time_us;
+    bool tracking_work;
+    bool tracking_meetings;
+} TimeTrackingEntry_t;
+
+typedef struct {
+    uint32_t magic;
+    TimeTrackingEntry_t tracking_entries[MAX_TIME_TRACKER_ENTRIES_COUNT];
+    uint current_entry;
+} TimeTrackerData_t;
+
+class TimeTracker : public Feature {
+  public:
+    explicit TimeTracker(KeysConfig& keys_config, Storage& storage)
+    : Feature(keys_config), storage(storage) {}
+    void handle(Buttons& buttons);
+
+  private:
+    TimeTrackerData_t data;
+    Storage& storage;
+
+    void tracker(const uint key, const Buttons& buttons);
+    void init();
+    std::string get_log(uint log_id) const;
+
+    void factory_init();
+    bool is_factory_required();
+};

--- a/firmware/features/time_tracker/include/time_tracker.hpp
+++ b/firmware/features/time_tracker/include/time_tracker.hpp
@@ -26,7 +26,16 @@
 
 #include "pico/stdlib.h"
 
+#define MICROSECONDS_IN_SECOND_COUNT 1'000'000
+#define SECONDS_IN_HOUR_COUNT 3600
+#define SECONDS_IN_MINUTE_COUNT 60
+
 #define MAX_TIME_TRACKER_ENTRIES_COUNT 31
+
+enum class TimeTrackerLog : uint {
+    CURRENT_WORK_TIME_REPORT     = 0,
+    CURRENT_MEETINGS_TIME_REPORT = 1,
+};
 
 typedef struct {
     uint64_t start_time_us;

--- a/firmware/features/time_tracker/time_tracker.cpp
+++ b/firmware/features/time_tracker/time_tracker.cpp
@@ -1,0 +1,170 @@
+/*
+ * 3-key Project
+ *
+ * This file is part of the 3-key project.
+ *
+ * Copyright (C) 2025 Dominik Trochowski <dominik.trochowski@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <limits>
+
+#include "keys_config.hpp"
+#include "storage_config.hpp"
+#include "time_tracker.hpp"
+
+void TimeTracker::init() {
+    const std::vector<KeyConfigTableEntry_t> keys = {
+        { 0, Key::NONE, Color::Red },
+        { 1, Key::NONE, Color::Green },
+        { 2, Key::NONE, Color::Blue },
+    };
+
+    for (const auto& entry : keys) {
+        keys_config.set_key_color(entry.id, entry.color);
+        keys_config.set_key_value(entry.id, entry.key);
+    }
+
+    storage.get_blob(BlobType::TIME_TRACKER_DATA, data);
+    if (is_factory_required())
+        factory_init();
+
+    keys_config.switch_leds_mode(LedsMode::HANDLED_BY_FEATURE);
+}
+
+void TimeTracker::factory_init() {
+    data.magic = BLOB_MAGIC;
+
+    for (auto& entry : data.tracking_entries) {
+        entry.start_time_us     = 0;
+        entry.work_time_us      = 0;
+        entry.meeting_time_us   = 0;
+        entry.tracking_work     = false;
+        entry.tracking_meetings = false;
+    }
+
+    data.current_entry = 0;
+
+    storage.save_blob(BlobType::TIME_TRACKER_DATA, data);
+}
+
+bool TimeTracker::is_factory_required() {
+    return (data.magic != BLOB_MAGIC);
+}
+
+void TimeTracker::tracker(const uint key, const Buttons& buttons) {
+    const uint64_t current_time_us = time_us_64();
+    auto& entry                    = data.tracking_entries[data.current_entry];
+
+    switch (key) {
+        case 0:
+            if (entry.tracking_work) {
+                entry.work_time_us += (current_time_us - entry.start_time_us);
+                entry.start_time_us = 0;
+                entry.tracking_work = false;
+                keys_config.led_disable(0);
+            } else {
+                if (entry.tracking_meetings) {
+                    entry.meeting_time_us += (current_time_us - entry.start_time_us);
+                    entry.tracking_meetings = false;
+                    keys_config.led_disable(1);
+                }
+                entry.start_time_us = current_time_us;
+                entry.tracking_work = true;
+                keys_config.led_enable(0);
+            }
+            break;
+
+        case 1:
+            if (entry.tracking_meetings) {
+                entry.meeting_time_us += (current_time_us - entry.start_time_us);
+                entry.start_time_us     = 0;
+                entry.tracking_meetings = false;
+                keys_config.led_disable(1);
+            } else {
+                if (entry.tracking_work) {
+                    entry.work_time_us += (current_time_us - entry.start_time_us);
+                    entry.tracking_work = false;
+                    keys_config.led_disable(0);
+                }
+                entry.start_time_us     = current_time_us;
+                entry.tracking_meetings = true;
+                keys_config.led_enable(1);
+            }
+            break;
+
+        case 2:
+            if (entry.tracking_work) {
+                entry.work_time_us += (current_time_us - entry.start_time_us);
+                entry.tracking_work = false;
+                keys_config.led_disable(0);
+            }
+            if (entry.tracking_meetings) {
+                entry.meeting_time_us += (current_time_us - entry.start_time_us);
+                entry.tracking_meetings = false;
+                keys_config.led_disable(1);
+            }
+
+            if (data.current_entry < MAX_TIME_TRACKER_ENTRIES_COUNT - 1) {
+                data.current_entry++;
+            } else {
+                data.current_entry = 0;
+            }
+
+            auto& new_entry             = data.tracking_entries[data.current_entry];
+            new_entry.start_time_us     = 0;
+            new_entry.work_time_us      = 0;
+            new_entry.meeting_time_us   = 0;
+            new_entry.tracking_work     = false;
+            new_entry.tracking_meetings = false;
+            break;
+    }
+    storage.save_blob(BlobType::TIME_TRACKER_DATA, data);
+}
+
+void TimeTracker::handle(Buttons& buttons) {
+    const auto pressed_key = buttons.get_pending_button();
+    if (pressed_key.has_value()) {
+        const uint key_id = pressed_key.value();
+        tracker(key_id, buttons);
+    }
+}
+
+std::string TimeTracker::get_log(uint log_id) const {
+    std::string log;
+    auto& entry = data.tracking_entries[data.current_entry];
+    switch (log_id) {
+        case 0: {
+            const uint64_t total_seconds = entry.work_time_us / 1'000'000;
+            const uint64_t hours         = total_seconds / 3600;
+            const uint64_t minutes       = (total_seconds % 3600) / 60;
+            const uint64_t seconds       = total_seconds % 60;
+
+            log = "Work: " + std::to_string(hours) + "h " + std::to_string(minutes) + "min " +
+                std::to_string(seconds) + "s";
+        } break;
+        case 1: {
+            const uint64_t total_seconds = entry.meeting_time_us / 1'000'000;
+            const uint64_t hours         = total_seconds / 3600;
+            const uint64_t minutes       = (total_seconds % 3600) / 60;
+            const uint64_t seconds       = total_seconds % 60;
+
+            log = "Meetings: " + std::to_string(hours) + "h " + std::to_string(minutes) + "min " +
+                std::to_string(seconds) + "s";
+        } break;
+        default: log = "Invalid log ID";
+    }
+    return log;
+}

--- a/firmware/keyscfg/include/keys_config.hpp
+++ b/firmware/keyscfg/include/keys_config.hpp
@@ -31,7 +31,7 @@
 #include "storage.hpp"
 
 typedef struct {
-    uint id;
+    uint key_id;
     Button key;
     Color color;
 } KeyConfigTableEntry_t;
@@ -136,7 +136,7 @@ class KeysConfig {
         if (key_id >= config.keys_count) {
             return;
         }
-        config.keys[key_id].value = btn;
+        config.keys[key_id].key_value = btn;
         storage.save_blob(BlobType::KEYS_CONFIG, config);
     }
 
@@ -151,6 +151,6 @@ class KeysConfig {
         if (key_id >= config.keys_count) {
             return Key::NONE;
         }
-        return config.keys[key_id].value;
+        return config.keys[key_id].key_value;
     }
 };

--- a/firmware/leds/include/leds.hpp
+++ b/firmware/leds/include/leds.hpp
@@ -53,6 +53,8 @@ class Leds {
     void refresh() const;
     void enable_all(bool r = false);
     void disable_all(bool r = false);
+    LedsMode mode() const;
+    void update_led_states();
 
   private:
     void push_led(const Led& led) const;

--- a/firmware/storage/include/storage_config.hpp
+++ b/firmware/storage/include/storage_config.hpp
@@ -41,5 +41,6 @@ enum class BlobType : uint {
     STORAGE_CONFIG,
     FEATURES_HANDLER_CONFIG,
     KEYS_CONFIG,
+    TIME_TRACKER_DATA,
     BLOBS_COUNT,
 };

--- a/firmware/terminal/include/terminal.hpp
+++ b/firmware/terminal/include/terminal.hpp
@@ -35,6 +35,7 @@ enum class Command {
     ERASE,
     CHANGE_COLOR,
     FEATURE,
+    TIME,
     UNKNOWN,
 };
 
@@ -60,6 +61,7 @@ class Terminal {
         { "erase", Command::ERASE },
         { "color", Command::CHANGE_COLOR },
         { "feature", Command::FEATURE },
+        { "time", Command::TIME },
     };
 
     bool dispatch_command(Command command, const std::vector<std::string>& params);
@@ -74,4 +76,5 @@ class Terminal {
     void reset_to_bootloader() const;
     bool handle_change_color_command(const std::vector<std::string>& params);
     bool handle_feature_command(const std::vector<std::string>& params);
+    bool handle_time_command(const std::vector<std::string>& params);
 };

--- a/firmware/terminal/terminal.cpp
+++ b/firmware/terminal/terminal.cpp
@@ -107,6 +107,9 @@ bool Terminal::dispatch_command(Command command, const std::vector<std::string>&
         case Command::FEATURE: {
             return handle_feature_command(params);
         }
+        case Command::TIME: {
+            return handle_time_command(params);
+        }
         default: return false;
     }
 }
@@ -160,6 +163,8 @@ bool Terminal::handle_feature_command(const std::vector<std::string>& params) {
         feature = FeatureType::NONE;
     } else if (feature_name == "ctrl_c_v") {
         feature = FeatureType::CTRL_C_V;
+    } else if (feature_name == "time-tracker") {
+        feature = FeatureType::TIME_TRACKER;
     } else {
         add_log("Error: Unknown feature");
         return false;
@@ -169,6 +174,26 @@ bool Terminal::handle_feature_command(const std::vector<std::string>& params) {
 
     add_log("Feature enabled: " + feature_name);
 
+    return true;
+}
+
+bool Terminal::handle_time_command(const std::vector<std::string>& params) {
+    if (params.size() < 1) {
+        add_log("Error: 1 argument required");
+        return false;
+    }
+
+    const std::string& type = params[0];
+    std::string log;
+    if (type == "work") {
+        log = f_handler.get_feature_log(FeatureType::TIME_TRACKER, 0);
+    } else if (type == "meetings") {
+        log = f_handler.get_feature_log(FeatureType::TIME_TRACKER, 1);
+    } else {
+        log = "Error: Unsupported argument";
+    }
+
+    add_log(log);
     return true;
 }
 

--- a/firmware/usb/hid.cpp
+++ b/firmware/usb/hid.cpp
@@ -26,7 +26,7 @@
 #include "hid.hpp"
 #include "usb_descriptors.h"
 
-void hid_task(const Buttons& buttons, FeaturesHandler& features_handler) {
+void hid_task(Buttons& buttons, FeaturesHandler& features_handler) {
     constexpr uint32_t interval_ms = 10;
     static uint32_t start_ms       = 0;
 


### PR DESCRIPTION
**time-tracker: changes to make time-tracker feature possible**

Introduce detecting if the button has been pressed and saving
this information. Other modules can get pending buttons and
handle them.

Allow to handle the leds state by features.

Introduce Feature::get_log() method, which returns log, which
can be then printed in the terminal.

**time-tracker: introduce 'time' command to terminal** 

It uses the storage to keep persistent data in nvm.
Support up to 31 tracing slots.

3 buttons are needed:
- first for start-stop work tracking
- second for start-stop meetings tracking
- third for moving to next tracking slot

**time-tracker: introduce 'time' command to terminal**

It prints the current slot work and meetings time to user.

**Example usage:**
```
3-key>time work
Work: 0h 1min 19s
3-key>time meetings
Meetings: 0h 1min 27s
```
