### PR TITLE
time: introduce time module

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,37 @@
+name: Build and Run Unit Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    container: dtrochow/3-key:v0.0.1
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - name: Build Unit Tests
+      working-directory: tests
+      run: |
+        mkdir build
+        cd build
+        cmake ..
+        make -j8
+
+    - name: Run Unit Tests
+      working-directory: tests/build
+      run: |
+        ctest --output-on-failure
+
+    - name: Upload test logs
+      if: failure()
+      uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+      with:
+        name: test-logs
+        path: tests/build/Testing/Temporary/LastTest.log

--- a/docs/adding_features.md
+++ b/docs/adding_features.md
@@ -1,4 +1,4 @@
-# Features
+# Adding Features
 
 ## Adding a New Feature to the Project
 This guide provides a step-by-step approach to add and integrate a new feature into the project. Each feature should be implemented as a module under the features directory.

--- a/docs/features/ctrl_c_v.md
+++ b/docs/features/ctrl_c_v.md
@@ -1,0 +1,30 @@
+# Ctrl C+V Feature
+
+The `Ctrl C+V Feature` provides seamless functionality for emulating keyboard shortcuts like `CTRL+C` and `CTRL+V` through hardware buttons. It integrates user-friendly LED feedback and is designed for use with USB HID devices, making it perfect for custom input hardware setups.
+
+---
+
+## Key Features
+
+1. **Simplified Copy-Paste Functionality**  
+   Map hardware buttons to perform `CTRL+C` (Copy) and `CTRL+V` (Paste) operations effortlessly.
+
+2. **Customizable Key and LED Configuration**  
+   - Assign specific keys to buttons according to your preferences.  
+   - Each button is paired with an LED that lights up when the button is pressed, providing instant feedback.
+
+3. **Dynamic LED Behavior**  
+   The LEDs only light up during button presses, conserving power and adding visual clarity during operation.
+
+4. **USB HID Compatibility**  
+   Works seamlessly with devices supporting the USB HID protocol, ensuring compatibility with a wide range of operating systems and applications.
+
+---
+
+**Setup**  
+   Ensure the device is connected to your computer via USB. The `Ctrl C+V Feature` is default feature.
+   It can be also enabled with the following command in serial terminal:
+
+```bash
+3-key>feature ctrl_c_v
+```

--- a/docs/features/time_tracker.md
+++ b/docs/features/time_tracker.md
@@ -1,0 +1,73 @@
+# TimeTracker Documentation
+
+The `TimeTracker` feature enables users to track time spent on various tasks, such as work and meetings, with the press of a button. It also provides visual feedback using LED lights and allows users to log and review their time data.
+
+---
+
+## Key Features
+
+1. **Track Work and Meeting Time**  
+   Log time spent on work or meetings using dedicated buttons.
+
+2. **Session Management**  
+   Easily switch between sessions to track separate periods of activity.
+
+3. **LED Feedback**  
+   LED lights provide real-time feedback:
+    - **Red**: Work tracking is active.
+    - **Green**: Meeting tracking is active.
+
+4. **View and Log Data**  
+   Generate detailed time logs to review your tracked activities.
+
+---
+
+## How to Use
+
+### Buttons and Their Functions
+
+- **Button 1 (Red)**:  
+   Toggles **Work Tracking**
+    - Press to start tracking work time
+    - Press again to stop tracking work time
+    - The red LED will light up when work tracking is active
+
+- **Button 2 (Green)**:  
+   Toggles **Meeting Tracking**
+    - Press to start tracking meeting time
+    - Press again to stop tracking meeting time
+    - The green LED will light up when meeting tracking is active
+
+- **Button 3 (Blue)**:
+   Ends the current session and starts a new one
+    - Stops any active tracking (work or meetings)
+    - Clears the LED indicators
+    - Moves to the next tracking entry, allowing you to start a new session
+
+---
+
+## Retrieving Data
+
+To review your tracked time, the `TimeTracker` provides logs that can be generated and displayed in serial terminal:
+
+1. **Work Time Log**:  
+   Displays the total time spent on work in the current session.  
+   Example Output:  
+   `2025-01-26 Work: 2h 15min 30s`
+
+2. **Meeting Time Log**:  
+   Displays the total time spent on meetings in the current session.  
+   Example Output:  
+   `2025-01-26 Meetings: 1h 45min 15s`
+
+---
+
+## Additional Notes
+
+- **Session Limit**: The TimeTracker supports up to a predefined maximum number of sessions. Once the limit is reached, it cycles back to the first session.
+- **Data Persistence**: All tracked time data is saved, ensuring that it remains available even after powering off the device.
+- **Factory Reset**: If needed, the feature can be reset to its factory settings, clearing all stored data.
+
+---
+
+With the `TimeTracker`, you can easily manage and review your time spent on work and meetings, ensuring better productivity and accountability.

--- a/docs/terminal/binary_mode.md
+++ b/docs/terminal/binary_mode.md
@@ -1,0 +1,114 @@
+# Terminal Binary Mode
+
+Terminal Binary Mode provides an efficient, structured protocol for exchanging commands and data between the terminal and the device. It uses binary packets to achieve low overhead and high-speed communication.
+
+---
+
+## Overview of Binary Mode
+
+Binary Mode is activated when the terminal detects a specific header byte sequence. Once active, the terminal operates in Binary Mode until a complete packet is processed or the communication is reset. Binary packets contain a structured header, optional payload, and a CRC32 checksum for validation.
+
+---
+
+## Packet Structure
+
+Binary packets are structured as follows:
+
+| Byte(s) | Description                  |
+|---------|------------------------------|
+| 0       | **Header 1**: Start byte (fixed value) |
+| 1       | **Header 2**: Second start byte (fixed value) |
+| 2       | **Command Type**: Specifies whether the operation is a `READ` or `WRITE`. |
+| 3       | **Command ID**: Identifies the specific command being executed. |
+| 4–7     | **Payload Length**: Length of the payload in bytes (little-endian). |
+| 8–N     | **Payload**: Command-specific data (optional, varies by command). |
+| N+1–N+4 | **CRC32**: Checksum for error detection (covers header and payload). |
+
+---
+
+## Command Payload Structure
+
+Each command can define its own payload structure. Here’s the general outline:
+
+1. **Write Mode (`Command Type = WRITE`)**:
+   - Sends data from the terminal to the device.
+   - Payload contains command-specific information.
+
+2. **Read Mode (`Command Type = READ`)**:
+   - Requests data from the device.
+   - Typically does not require a payload.
+
+### Example: `SYNC_TIME` Command Payload (Write Mode)
+
+| Byte(s) | Description                 |
+|---------|-----------------------------|
+| 0–7     | Timestamp (64-bit, little-endian). |
+
+---
+
+### Response Structure
+
+Responses sent by the device follow the same basic structure as requests but without a payload unless the command specifies one.
+
+| Byte(s) | Description                  |
+|---------|------------------------------|
+| 0       | **Header 1**: Start byte. |
+| 1       | **Header 2**: Second start byte. |
+| 2       | **Status**: Command execution status (`SUCCESS`, `INVALID_PAYLOAD`, etc.). |
+| 3       | **Command ID**: ID of the command being responded to. |
+| 4–7     | **Payload Length**: Length of the payload (usually `0x00 0x00 0x00 0x00` if no payload). |
+| 8–11    | **CRC32**: Checksum covering the response.
+
+### Common Response Status Codes
+
+| Status Code | Meaning                     |
+|-------------|-----------------------------|
+| `0x00`      | `SUCCESS`: Command executed successfully. |
+| `0x01`      | `INVALID_PAYLOAD`: Payload size or format is invalid. |
+| `0x02`      | `UNSUPPORTED_CMP_TYPE`: Unsupported command type (e.g., `READ` for `SYNC_TIME`). |
+
+---
+
+## Commands and Descriptions
+
+The following commands are currently supported:
+
+### 1. `SYNC_TIME`
+Synchronizes the device's internal time with the provided timestamp.
+
+- **Command Type**: `WRITE`
+- **Command ID**: `0x01`
+- **Payload**:
+    - **Bytes 0–7**: Timestamp in microseconds (64-bit, little-endian).
+
+- **Response**
+    - **Success**: The device sets its internal time and returns a success response
+    - **Failure**: Returns an error status if the payload is invalid or the command type is unsupported
+
+## Example Workflow
+
+### Synchronizing Time
+
+1. **Send Request**
+    - Command: `SYNC_TIME`
+    - Command Type: `WRITE`
+    - Payload: Timestamp (e.g., `0x00 0x00 0x1A 0xE1 0x4E 0x6C 0x00 0x00` for `1700000000000` microseconds)
+
+2. **Device Processes**
+    - Validates the header, payload, and CRC32
+    - Sets its internal clock to the provided timestamp
+
+3. **Receive Response**
+    - Success Response:
+     ```
+      Header 1: 0xAA
+      Header 2: 0xBB
+      Status: 0x00 (SUCCESS)
+      Command ID: 0x01 (SYNC_TIME)
+      Payload Length: 0x00 0x00 0x00 0x00
+      CRC32: Calculated checksum.
+     ```
+
+---
+
+This document outlines the structure, functionality, and use cases of Terminal Binary Mode, providing a clear understanding for developers. For advanced scenarios, consult the implementation details or reach out to support.

--- a/docs/terminal/text_mode.md
+++ b/docs/terminal/text_mode.md
@@ -1,0 +1,156 @@
+# Terminal Text Mode
+
+Text Mode provides a human-readable interface for interacting with the terminal. It allows users to execute predefined commands via text input, offering a simple and accessible way to configure and query the device's functionality.
+
+---
+
+## Overview
+
+In Text Mode, commands are entered as plain text strings. Each command may include parameters to specify additional details. The mode supports standard editing keys like backspace and enter for user convenience.
+
+### Key Features:
+- Commands are processed line-by-line when the Enter key is pressed.
+- Basic editing with backspace.
+- Validation of input to prevent invalid commands or parameters.
+
+---
+
+## Supported Commands
+
+Below is a list of commands supported by Text Mode, along with their usage and descriptions:
+
+### 1. `reset`
+Resets the device and enters bootloader mode.
+
+**Usage**
+```bash
+3-key>reset
+```
+
+**Description**
+
+Restarts the device and prepares it for firmware updates.
+
+---
+
+### 2. `erase`
+Erases all data in flash storage.
+
+**Usage**
+```bash
+3-key>erase
+```
+
+**Description**
+
+- Clears all data stored in flash memory
+- Returns a confirmation log message upon success
+
+---
+
+### 3. `change_color`
+Changes the color of a specific button.
+
+**Usage**
+```bash
+3-key>change_color <button_id> <color>
+```
+
+**Parameters**
+
+- <button_id>: Numeric ID of the button (must be a valid button ID)
+- <color>: Color name (red, green, or blue)
+
+**Example**
+```bash
+3-key>change_color 1 red
+```
+
+**Description**
+
+- Changes the color of the button identified by <button_id> to the specified <color>
+- Logs an error message if the button ID or color is invalid
+
+---
+
+### 4. `feature`
+Enables or switches to a specific feature.
+
+**Usage**
+```bash
+3-key>feature <feature_name>
+```
+
+**Parameters**
+
+- `<feature_name>`: Name of the feature to enable. Supported values:
+    - `none`: Disables all features
+    - `ctrl_c_v`: Enables copy-paste functionality
+    - `time-tracker`: Activates time tracking
+
+**Example**
+
+```bash
+3-key>feature time-tracker
+```
+
+**Description**
+
+- Enables the specified feature and disables any previously active features
+- Logs a success message or an error if the feature name is invalid
+
+---
+
+### 5. `time`
+Fetches time-tracking logs for different categories.
+
+**Usage**
+```bash
+3-key>time <category>
+```
+
+**Parameters**
+- `<category>`: Time log category. Supported values:
+    - `work`: Fetches work time logs
+    - `meetings`: Fetches meeting time logs
+
+**Example**
+```bash
+3-key>time work
+```
+
+**Description**
+
+- Retrieves time logs for the specified category
+- Returns an error if the time-tracker feature is not active
+
+---
+
+## Command Parsing and Processing
+
+### Command Execution Workflow
+1. User inputs a command string and presses Enter
+2. The string is split into the command name and parameters
+3. The system maps the command name to a predefined operation
+4. Parameters are validated, and the command is dispatched
+5. Logs are updated with the result (success or error)
+
+---
+
+## Logs and Feedback
+
+Logs provide immediate feedback on the execution of commands. They include:
+
+- Success messages when commands execute correctly
+- Error messages for invalid commands or parameters
+
+**Example Logs**:
+```text
+Flash storage erased
+Changing button 1 color to red
+Error: change_color requires 2 parameters
+```
+
+---
+
+This documentation provides an overview of Text Mode, its supported commands, and usage guidelines. For advanced configurations or new features, consult the development team or refer to future updates.

--- a/firmware/3-key.cpp
+++ b/firmware/3-key.cpp
@@ -31,6 +31,7 @@
 #include "leds.hpp"
 #include "storage.hpp"
 #include "terminal.hpp"
+#include "time.hpp"
 #include "tud.hpp"
 
 Leds* g_leds       = nullptr;
@@ -70,10 +71,12 @@ int main(void) {
     g_leds    = &leds;
     multicore_launch_core1(leds_task_on_core1);
 
-    FeaturesHandler f_handler(storage, keys);
+    Time time;
+
+    FeaturesHandler f_handler(storage, keys, time);
     f_handler.init();
 
-    Terminal t(storage, keys, f_handler);
+    Terminal t(storage, keys, f_handler, time);
     CdcDevice cdc(t);
 
     initialize_tud();

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -45,6 +45,7 @@ add_subdirectory(storage)
 add_subdirectory(terminal)
 add_subdirectory(keyscfg)
 add_subdirectory(features)
+add_subdirectory(time)
 
 target_link_libraries(${project_name} 
     pico_stdlib 
@@ -56,6 +57,7 @@ target_link_libraries(${project_name}
     terminal
     keyscfg
     features_handler
+    time
 )
 
 pico_add_extra_outputs(${project_name})

--- a/firmware/features/features_handler/CMakeLists.txt
+++ b/firmware/features/features_handler/CMakeLists.txt
@@ -9,4 +9,5 @@ target_link_libraries(${modulename}
     buttons
     ctrl_c_v
     time_tracker
+    time
 )

--- a/firmware/features/features_handler/features_handler.cpp
+++ b/firmware/features/features_handler/features_handler.cpp
@@ -23,9 +23,11 @@
 #include "features.hpp"
 #include "keys_config.hpp"
 #include "storage.hpp"
+#include "time.hpp"
+#include "time_tracker.hpp"
 
-FeaturesHandler::FeaturesHandler(Storage& storage, KeysConfig& keys_config)
-: storage(storage), keys_config(keys_config) {}
+FeaturesHandler::FeaturesHandler(Storage& storage, KeysConfig& keys_config, Time& time)
+: storage(storage), keys_config(keys_config), time(time) {}
 
 void FeaturesHandler::init() {
     (void)storage.get_blob(BlobType::FEATURES_HANDLER_CONFIG, config);
@@ -42,7 +44,7 @@ void FeaturesHandler::init() {
 
 void FeaturesHandler::initialize_features() {
     features[FeatureType::CTRL_C_V]     = std::make_unique<CtrlCVFeature>(keys_config);
-    features[FeatureType::TIME_TRACKER] = std::make_unique<TimeTracker>(keys_config, storage);
+    features[FeatureType::TIME_TRACKER] = std::make_unique<TimeTracker>(keys_config, storage, time);
 }
 
 void FeaturesHandler::factory_init() {

--- a/firmware/features/features_handler/include/features_handler.hpp
+++ b/firmware/features/features_handler/include/features_handler.hpp
@@ -24,6 +24,7 @@
 #include "buttons.hpp"
 #include "keys_config.hpp"
 #include "storage.hpp"
+#include "time.hpp"
 
 #include <memory>
 #include <unordered_map>
@@ -56,7 +57,7 @@ class Feature {
 
 class FeaturesHandler {
   public:
-    FeaturesHandler(Storage& storage, KeysConfig& keys_config);
+    FeaturesHandler(Storage& storage, KeysConfig& keys_config, Time& time);
     ~FeaturesHandler() = default;
 
     void init();
@@ -71,6 +72,7 @@ class FeaturesHandler {
     Storage& storage;
     std::unordered_map<FeatureType, std::unique_ptr<Feature>> features;
     KeysConfig& keys_config;
+    Time& time;
 
     void initialize_features();
     bool is_factory_required() const;

--- a/firmware/features/time_tracker/CMakeLists.txt
+++ b/firmware/features/time_tracker/CMakeLists.txt
@@ -8,4 +8,5 @@ target_link_libraries(${modulename}
     pico_stdlib 
     features_handler
     usb
+    time
 )

--- a/firmware/features/time_tracker/include/time_tracker.hpp
+++ b/firmware/features/time_tracker/include/time_tracker.hpp
@@ -23,6 +23,7 @@
 
 #include "buttons.hpp"
 #include "features_handler.hpp"
+#include "time.hpp"
 
 #include "pico/stdlib.h"
 
@@ -43,6 +44,7 @@ typedef struct {
     uint64_t meeting_time_us;
     bool tracking_work;
     bool tracking_meetings;
+    DateTime_t tracking_date;
 } TimeTrackingEntry_t;
 
 typedef struct {
@@ -53,18 +55,21 @@ typedef struct {
 
 class TimeTracker : public Feature {
   public:
-    explicit TimeTracker(KeysConfig& keys_config, Storage& storage)
-    : Feature(keys_config), storage(storage) {}
+    explicit TimeTracker(KeysConfig& keys_config, Storage& storage, Time& time)
+    : Feature(keys_config), storage(storage), time(time) {}
     void handle(Buttons& buttons);
 
   private:
     TimeTrackerData_t data;
     Storage& storage;
+    Time& time;
 
+    void set_tracking_date();
     void tracker(const uint key, const Buttons& buttons);
     void init();
     std::string get_log(uint log_id) const;
 
     void factory_init();
-    bool is_factory_required();
+    bool is_factory_required() const;
+    bool is_date_empty(DateTime_t& date_time) const;
 };

--- a/firmware/terminal/CMakeLists.txt
+++ b/firmware/terminal/CMakeLists.txt
@@ -11,4 +11,5 @@ target_link_libraries(${modulename}
         storage
         keyscfg
         features_handler
+        time
 )

--- a/firmware/terminal/binary_mode.cpp
+++ b/firmware/terminal/binary_mode.cpp
@@ -23,7 +23,7 @@
 #include <cstdint>
 #include <cstring>
 
-BinaryMode::BinaryMode() : binary_mode(false) {}
+BinaryMode::BinaryMode(Time& time) : binary_mode(false), time(time) {}
 
 std::span<uint8_t> BinaryMode::handle(uint8_t ch) {
     binary_buffer.push_back(ch);
@@ -152,6 +152,7 @@ std::span<uint8_t> BinaryMode::handle_sync_time_command(const std::vector<uint8_
 
         uint64_t received_time;
         std::memcpy(&received_time, payload.data(), sizeof(received_time));
+        time.set_current_time_us(received_time);
     } else {
         /* READ */
         return create_binary_response(BinaryCommandID::SYNC_TIME, BinaryCommandStatus::UNSUPPORTED_CMP_TYPE);

--- a/firmware/terminal/include/binary_mode.hpp
+++ b/firmware/terminal/include/binary_mode.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "time.hpp"
 #include <cstdint>
 #include <span>
 #include <vector>
@@ -52,7 +53,7 @@ enum class BinaryCommandStatus : uint8_t {
 
 class BinaryMode {
   public:
-    BinaryMode();
+    BinaryMode(Time& time);
     ~BinaryMode() = default;
 
     std::span<uint8_t> handle(uint8_t ch);
@@ -60,6 +61,7 @@ class BinaryMode {
     void check_binary_mode(uint8_t ch);
 
   private:
+    Time& time;
     bool binary_mode;
     std::vector<uint8_t> binary_buffer;
 

--- a/firmware/terminal/include/terminal.hpp
+++ b/firmware/terminal/include/terminal.hpp
@@ -30,6 +30,7 @@
 
 #include "binary_mode.hpp"
 #include "text_mode.hpp"
+#include "time.hpp"
 
 class Terminal {
   private:
@@ -38,7 +39,7 @@ class Terminal {
     BinaryMode binary_mode;
 
   public:
-    Terminal(Storage& storage, KeysConfig& keys, FeaturesHandler& f_handler);
+    Terminal(Storage& storage, KeysConfig& keys, FeaturesHandler& f_handler, Time& time);
     ~Terminal() = default;
 
     std::span<uint8_t> terminal(char byte);

--- a/firmware/time/CMakeLists.txt
+++ b/firmware/time/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(modulename "time")
+set(SOURCES 
+        time.cpp
+)
+add_library(${modulename} ${SOURCES})
+target_include_directories(${modulename} PUBLIC include)
+target_link_libraries(${modulename})

--- a/firmware/time/include/time.hpp
+++ b/firmware/time/include/time.hpp
@@ -19,18 +19,34 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "terminal.hpp"
-#include "binary_mode.hpp"
+#pragma once
 
-Terminal::Terminal(Storage& storage, KeysConfig& keys, FeaturesHandler& f_handler, Time& time)
-: text_mode(storage, keys, f_handler), binary_mode(time) {}
+#include <cstdint>
+#include <iomanip>
+#include <sstream>
+#include <string>
 
-std::span<uint8_t> Terminal::terminal(char byte) {
-    binary_mode.check_binary_mode(static_cast<uint8_t>(byte));
+typedef struct {
+    uint16_t year;
+    uint8_t month;
+    uint8_t day;
+    uint8_t hour;
+    uint8_t minute;
+    uint8_t second;
+} DateTime_t;
 
-    if (binary_mode.is_binary_mode()) {
-        return binary_mode.handle(static_cast<uint8_t>(byte));
-    } else {
-        return text_mode.handle(byte);
-    }
-}
+class Time {
+  public:
+    Time();
+    ~Time();
+
+    uint64_t get_current_time_us() const;
+    uint64_t get_current_time_ms() const;
+    uint64_t get_current_time_s() const;
+    DateTime_t get_current_date_and_time() const;
+    std::string get_current_date_and_time_string() const;
+    void set_current_time_us(uint64_t time_us);
+
+  private:
+    uint64_t current_time_us;
+};

--- a/firmware/time/test/time_test.cpp
+++ b/firmware/time/test/time_test.cpp
@@ -1,0 +1,80 @@
+/*
+ * 3-key Project
+ *
+ * This file is part of the 3-key project.
+ *
+ * Copyright (C) 2025 Dominik Trochowski <dominik.trochowski@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "time.hpp"
+#include <gtest/gtest.h>
+
+// Test fixture for Time class
+class TimeTest : public ::testing::Test {
+  protected:
+    Time time; // Time object for testing
+};
+
+TEST_F(TimeTest, DefaultInitialization) {
+    EXPECT_EQ(time.get_current_time_us(), 0);
+    EXPECT_EQ(time.get_current_time_ms(), 0);
+    EXPECT_EQ(time.get_current_time_s(), 0);
+}
+
+TEST_F(TimeTest, SetCurrentTime) {
+    uint64_t test_time_us = 1234567890123;
+    time.set_current_time_us(test_time_us);
+    EXPECT_EQ(time.get_current_time_us(), test_time_us);
+    EXPECT_EQ(time.get_current_time_ms(), test_time_us / 1000);
+    EXPECT_EQ(time.get_current_time_s(), test_time_us / 1000000);
+}
+
+TEST_F(TimeTest, GetCurrentDateAndTime) {
+    // Set time to 1st January 2022, 00:00:00 (seconds since epoch: 1640995200)
+    uint64_t test_time_us = 1640995200ULL * 1000000;
+    time.set_current_time_us(test_time_us);
+
+    DateTime_t dt = time.get_current_date_and_time();
+    EXPECT_EQ(dt.year, 2022);
+    EXPECT_EQ(dt.month, 1);
+    EXPECT_EQ(dt.day, 1);
+    EXPECT_EQ(dt.hour, 0);
+    EXPECT_EQ(dt.minute, 0);
+    EXPECT_EQ(dt.second, 0);
+}
+
+TEST_F(TimeTest, GetCurrentDateAndTimeString) {
+    // Set time to 31st December 2021, 23:59:59
+    uint64_t test_time_us = 1640995199ULL * 1000000;
+    time.set_current_time_us(test_time_us);
+
+    std::string expected = "31.12.2021 23:59:59";
+    EXPECT_EQ(time.get_current_date_and_time_string(), expected);
+}
+
+TEST_F(TimeTest, LeapYearHandling) {
+    // Set time to 29th February 2020, 12:00:00 (a leap year)
+    uint64_t test_time_us = 1582977600ULL * 1000000;
+    time.set_current_time_us(test_time_us);
+
+    DateTime_t dt = time.get_current_date_and_time();
+    EXPECT_EQ(dt.year, 2020);
+    EXPECT_EQ(dt.month, 2);
+    EXPECT_EQ(dt.day, 29);
+    EXPECT_EQ(dt.hour, 12);
+    EXPECT_EQ(dt.minute, 0);
+    EXPECT_EQ(dt.second, 0);
+}

--- a/firmware/time/time.cpp
+++ b/firmware/time/time.cpp
@@ -1,0 +1,115 @@
+/*
+ * 3-key Project
+ *
+ * This file is part of the 3-key project.
+ *
+ * Copyright (C) 2025 Dominik Trochowski <dominik.trochowski@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "time.hpp"
+
+enum class Month : uint8_t {
+    JANUARY   = 1,
+    FEBRUARY  = 2,
+    MARCH     = 3,
+    APRIL     = 4,
+    MAY       = 5,
+    JUNE      = 6,
+    JULY      = 7,
+    AUGUST    = 8,
+    SEPTEMBER = 9,
+    OCTOBER   = 10,
+    NOVEMBER  = 11,
+    DECEMBER  = 12,
+};
+
+Time::Time() : current_time_us(0) {}
+Time::~Time() = default;
+
+uint64_t Time::get_current_time_us() const {
+    return current_time_us;
+}
+
+uint64_t Time::get_current_time_ms() const {
+    return current_time_us / 1000;
+}
+
+uint64_t Time::get_current_time_s() const {
+    return current_time_us / 1000000;
+}
+DateTime_t Time::get_current_date_and_time() const {
+    constexpr uint16_t EPOCH_YEAR             = 1970;
+    constexpr uint32_t SECONDS_IN_MINUTE      = 60;
+    constexpr uint32_t SECONDS_IN_HOUR        = 60 * SECONDS_IN_MINUTE;
+    constexpr uint32_t SECONDS_IN_DAY         = 24 * SECONDS_IN_HOUR;
+    constexpr uint32_t SECONDS_IN_COMMON_YEAR = 365 * SECONDS_IN_DAY;
+    constexpr uint32_t SECONDS_IN_LEAP_YEAR   = 366 * SECONDS_IN_DAY;
+
+    constexpr uint8_t DAYS_IN_MONTH[] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+
+    uint64_t total_seconds = get_current_time_s();
+    uint16_t year          = EPOCH_YEAR;
+
+    while (true) {
+        const bool is_leap       = (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0));
+        uint32_t seconds_in_year = is_leap ? SECONDS_IN_LEAP_YEAR : SECONDS_IN_COMMON_YEAR;
+        if (total_seconds >= seconds_in_year) {
+            total_seconds -= seconds_in_year;
+            year++;
+        } else {
+            break;
+        }
+    }
+
+    Month month = Month::JANUARY;
+    while (true) {
+        const bool is_leap         = (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0));
+        uint8_t days_in_this_month = DAYS_IN_MONTH[static_cast<uint8_t>(month) - 1];
+        if (is_leap && month == Month::FEBRUARY) {
+            days_in_this_month++;
+        }
+        const uint32_t seconds_in_month = days_in_this_month * SECONDS_IN_DAY;
+        if (total_seconds >= seconds_in_month) {
+            total_seconds -= seconds_in_month;
+            month = static_cast<Month>(static_cast<uint8_t>(month) + 1);
+        } else {
+            break;
+        }
+    }
+
+    const uint8_t day = total_seconds / SECONDS_IN_DAY + 1;
+    total_seconds %= SECONDS_IN_DAY;
+    const uint8_t hour = total_seconds / SECONDS_IN_HOUR;
+    total_seconds %= SECONDS_IN_HOUR;
+    const uint8_t minute = total_seconds / SECONDS_IN_MINUTE;
+    const uint8_t second = total_seconds % SECONDS_IN_MINUTE;
+
+    return { year, static_cast<uint8_t>(month), day, hour, minute, second };
+}
+
+std::string Time::get_current_date_and_time_string() const {
+    DateTime_t dt = get_current_date_and_time();
+    std::ostringstream oss;
+    oss << std::setfill('0') << std::setw(2) << static_cast<unsigned>(dt.day) << "." << std::setw(2)
+        << static_cast<unsigned>(dt.month) << "." << std::setw(4) << dt.year << " " << std::setw(2)
+        << static_cast<unsigned>(dt.hour) << ":" << std::setw(2) << static_cast<unsigned>(dt.minute)
+        << ":" << std::setw(2) << static_cast<unsigned>(dt.second);
+    return oss.str();
+}
+
+void Time::set_current_time_us(uint64_t time_us) {
+    current_time_us = time_us;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,9 +53,15 @@ plugins:
         - read_excel
 nav:
   - Home: index.md
+  - Features:
+      - CTRL+C/V: features/ctrl_c_v.md
+      - Time-Tracker: features/time_tracker.md
+  - Terminal:
+      - Text Mode: terminal/text_mode.md
+      - Binary Mode: terminal/binary_mode.md
   - Hardware: hardware.md
   - Development:
       - Environment & Tools: development.md
-      - Features: features.md
+      - Adding Features: adding_features.md
   - Blog: blog/index.md
 exclude_docs: README.md

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.14)
+project(time_unit_tests)
+
+# Set C++ Standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_BUILD_TYPE Debug)
+
+# GoogleTest setup
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.15.2
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
+set(FIRMWARE_PATH ${CMAKE_CURRENT_LIST_DIR}/../firmware)
+
+# -------------------------------------------------------------------------- #
+#                              Test Executables                              #
+# -------------------------------------------------------------------------- #
+
+add_executable(time_test
+  ${FIRMWARE_PATH}/time/test/time_test.cpp
+)
+
+# -------------------------------------------------------------------------- #
+#                                  Libraries                                 #
+# -------------------------------------------------------------------------- #
+
+add_subdirectory(../firmware/time ${CMAKE_CURRENT_BINARY_DIR}/firmware_time)
+
+target_link_libraries(time_test
+  time
+  gtest_main
+)
+
+# -------------------------------------------------------------------------- #
+#                                    Tests                                   #
+# -------------------------------------------------------------------------- #
+
+add_test(NAME time_test COMMAND time_test)


### PR DESCRIPTION
time: introduce time module
It requires sync_time command to be executed each time the
device is power cycled.

Then the date, time, etc. can be retrieved from it.

The `unittests.yml` workflow will be blocking all merges
to main branch.

docs: document new features and new terminal modes