### PR TITLE
Add Windows support for the USB device #39

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     libusb-1.0-0-dev \
     openocd \
     gdb-multiarch \
+    picocom \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/raspberrypi/pico-sdk.git /opt/pico-sdk \

--- a/firmware/usb/usb_descriptors.cpp
+++ b/firmware/usb/usb_descriptors.cpp
@@ -29,7 +29,7 @@
 
 #define USB_PID 0x000A
 #define USB_VID 0x2E8A
-#define USB_BCD 0x0210
+#define USB_BCD 0x0200
 
 //--------------------------------------------------------------------+
 // Device Descriptors


### PR DESCRIPTION
Adding picocom to the Docker container.

When connecting the 3-key device to a Windows host, it was identified as an invalid USB device because the USB 2.10 descriptor requires additional feature descriptors. Reducing the USB descriptor version to 2.00 resolves this issue.

The ChatGPT response with sources regarding the Windows USB descriptors:
"Setting the bcdUSB field to 0x0210 (USB 2.1) in your device descriptor indicates compliance with USB 2.1 specifications. Windows expects USB 2.1 devices to support features like the Binary Device Object Store (BOS) descriptor and Link Power Management (LPM). If these are absent, Windows may fail to enumerate the device. Therefore, if your device doesn't implement these features, it's advisable to set bcdUSB to 0x0200 (USB 2.0) to ensure proper recognition by Windows."
**Source:** ChatGPT & https://techcommunity.microsoft.com/blog/microsoftusbblog/usb-2-1-2-0-1-1-device-enumeration-changes-in-windows-8/270775